### PR TITLE
Task 3 - UI/UX

### DIFF
--- a/docs/adr/ADR-0005-per-deployment-utilization-share.md
+++ b/docs/adr/ADR-0005-per-deployment-utilization-share.md
@@ -1,0 +1,32 @@
+# ADR-0005: Per-deployment Utilization Shares with Implied Reserve
+
+Status: Accepted
+
+Date: 2025-09-06
+
+## Context
+
+The PRD v1 modeled a global GPU memory utilization `U ∈ [0,1]` and a fixed per‑GPU runtime reserve (GB). The UI needs more intuitive control over how multiple deployments share a GPU.
+
+## Decision
+
+- Introduce a per‑deployment utilization share `utilizationShare ∈ [0,1]` configured during model selection.
+- For each GPU, compute the total share as `Σ U_d` across deployments assigned to that GPU in Step 3. The implied runtime reserve fraction is `max(0, 1 − Σ U_d)`.
+- Remove global `U` and fixed `reserve GB` UI. Keep units toggle in Global Controls.
+- Default `utilizationShare` = 0.90 for a single deployment; users can rebalance across multiple deployments.
+
+## Consequences
+
+- UI changes: Step 2 includes a `Utilization U` control per deployment; Results view shows ΣU and implied reserve per GPU.
+- Domain impact: Aggregation formulas will be adjusted in Task 4.x to apply per‑deployment shares when computing budgets and free capacity (instead of global `U` and fixed reserve GB).
+- Validation: Warn when `Σ U_d > 1` on any GPU; leave as soft constraint in v1.
+
+## Alternatives Considered
+
+- Keep global `U` + fixed reserve (simpler, less flexible). Rejected based on UX clarity across overlapping deployments.
+- Per‑GPU manual reserve entry (more controls, more complexity). Rejected for v1.
+
+## Traceability
+
+- PRD: UI/UX refinement request during Task 3.0
+- ARCH-v1: Data/UI boundaries unchanged; `Deployment` type extended with optional `utilizationShare`.

--- a/docs/architecture/ARCH-v1.md
+++ b/docs/architecture/ARCH-v1.md
@@ -14,15 +14,15 @@ Allowed imports: UI→App; App→Domain|Data|Shared; Domain→Shared; Data→Sha
 
 ## Key Contracts
 
-- Types (shared/types.ts)
+- Types (`src/shared/types.ts`)
   - `Gpu { id: string; name: string; vramBytes: number }`
   - `UnitPreference = 'GiB'|'GB'`
   - `Model { id: string; name: string; paramsB: number; layers: number; hiddenSize: number; heads: number; numKeyValueHeads: number; defaultWeightDtype: DType; defaultKvDtype: KvDType }`
   - `DType = 'fp16'|'bf16'|'fp32'|'q8'|'q4'`
   - `KvDType = 'fp16'|'bf16'|'fp8'|'int8'`
-  - `Deployment { id: string; modelId: string; assignedGpuIds: string[]; tp: number; weightDtype: DType; kvDtype: KvDType; kvOverheadPct: number; replicationOverheadPct: number; maxModelLen: number; maxNumSeqs: number }`
+  - `Deployment { id: string; modelId: string; assignedGpuIds: string[]; tp: number; weightDtype: DType; kvDtype: KvDType; kvOverheadPct: number; replicationOverheadPct: number; maxModelLen: number; maxNumSeqs: number; utilizationShare?: number }`
 
-- Domain (domain/memory.ts)
+- Domain (`src/domain/memory.ts`)
   - `bytesPerParam(dtype: DType): number`
   - `bytesPerKvElem(dtype: KvDType): number`
   - `weightBytesPerGpu(paramsB: number, dtype: DType, tp: number, replicationOverheadPct: number): number`
@@ -34,16 +34,16 @@ Allowed imports: UI→App; App→Domain|Data|Shared; Domain→Shared; Data→Sha
   - `suggestMaxNumSeq(budgetBytes: number, kvPerTokenPerGpu: number, modelLen: number): number`
   - `fitChecks(perGpu: Map<string, ...>): Array<{gpuId: string; ok: boolean; reason?: string}>`
 
-- Data (data/catalog.ts)
+- Data (`src/data/catalog.ts`)
   - `listGpus(): Gpu[]`
   - `listModels(): Model[]`
   - `getModelById(id: string): Model | undefined`
   - JSON schema:
-    - GPUs (`data/gpus.json`): `{ id: string, name: string, vendor?: string, vramBytes: number }`
-    - Models (`data/models.json`): `{ id: string, name: string, paramsB: number, layers: number, hiddenSize: number, heads: number, numKeyValueHeads: number, defaultWeightDtype: DType, defaultKvDtype: KvDType }`
+    - GPUs (`src/data/gpus.json`): `{ id: string, name: string, vendor?: string, vramBytes: number }`
+    - Models (`src/data/models.json`): `{ id: string, name: string, paramsB: number, layers: number, hiddenSize: number, heads: number, numKeyValueHeads: number, defaultWeightDtype: DType, defaultKvDtype: KvDType }`
   - Seed entries: as listed in PRD “Initial Catalog (v1)”. Ambiguous capacities are added as placeholders pending confirmation.
 
-- Shared utils (shared/units.ts)
+- Shared utils (`src/shared/units.ts`)
   - `bytesToGiB(bytes: number): number`
   - `bytesToGB(bytes: number): number`
   - `formatBytes(bytes: number, unit: UnitPreference, decimals = 1): string`
@@ -51,7 +51,7 @@ Allowed imports: UI→App; App→Domain|Data|Shared; Domain→Shared; Data→Sha
 
 ## Data Flow
 
-UI (forms/stepper & deployment roster) → App (state + validation) → Domain (pure estimates, per‑GPU aggregation) → App (compose results) → UI (bars)
+UI (stepper: GPUs → Models (with U share) → Workload → Results) → App (state + validation + derived ΣU/reserve) → Domain (pure estimates, per‑GPU aggregation) → App (compose results) → UI (bars)
 
 State lives in App. Domain is stateless. Data is static JSON read at startup.
 

--- a/docs/tasks/llm-gpu-calc/v1/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v1/tasks.md
@@ -64,7 +64,7 @@
     - Gates: Boundaries; Tests (basic data load/shape checks).
     - Traceability: PRD Initial Catalog; ARCH Data schema.
     - Est: 1–2h
-  - [x] 2.2 Seed `data/models.json` and `data/gpus.json` with the initial lists from PRD (capacities confirmed)
+  - [x] 2.2 Seed `src/data/models.json` and `src/data/gpus.json` with the initial lists from PRD (capacities confirmed)
     - Acceptance: All listed models/GPUs present with consistent ids/names; GPU capacities stored as `vramBytes`; simple loader returns typed arrays.
     - Gates: Boundaries.
     - Traceability: PRD Initial Catalog; ARCH Data schema.
@@ -75,30 +75,30 @@
     - Traceability: PRD Initial Catalog.
     - Est: 0.5–1h
 
-- [ ] 3.0 UI/App: Deployment roster + Stepper
-  - [ ] 3.1 Create deployments, assign GPUs, set TP, dtypes, overheads
+- [x] 3.0 UI/App: Deployment roster + Stepper
+  - [x] 3.1 Create deployments, assign GPUs, set TP, dtypes, overheads
     - Acceptance: Users can add/edit/remove deployments; assign GPUs; set TP, weight/kv dtypes, overheads, `max_model_len`, `max_num_seqs`.
     - Gates: Boundaries; No new runtime deps.
     - Traceability: PRD User Stories; PRD Acceptance Criteria (Deployment).
     - Est: 2–4h
-  - [ ] 3.2 Global config: utilization U [0..1], runtime reserve (GB)
-    - Acceptance: Global `U` slider/input and runtime reserve input wired into state; defaults applied (U=0.90, reserve=2GB).
+  - [x] 3.2 Utilization shares and implied reserve
+    - Acceptance: Each deployment has a `U` share [0..1] set during model selection; Results show per‑GPU ΣU and implied reserve `1−ΣU`. See ADR‑0005.
     - Gates: Boundaries.
-    - Traceability: PRD Detailed Inputs; UI Styles.
+    - Traceability: PRD Detailed Inputs; ADR‑0005.
     - Est: 1–2h
-  - [ ] 3.3 Validation: tp ≤ assigned GPUs; soft warnings for mixed capacities
+  - [x] 3.3 Validation: tp ≤ assigned GPUs; soft warnings for mixed capacities
     - Acceptance: Hard validation blocks TP > assigned; soft warning banner for mixed capacities; states are testable.
     - Gates: Boundaries.
     - Traceability: PRD Multi-GPU Behavior.
     - Est: 1–2h
-  - [ ] 3.4 Units toggle (GiB|GB) with localStorage persistence; capacity labels show both
-    - Acceptance: Toggle persists; re-renders values; capacity shows dual label (e.g., 80 GB (74.5 GiB)).
+  - [x] 3.4 Units toggle (GiB|GB) with localStorage persistence; results reflect unit
+    - Acceptance: Toggle persists; re-renders values; capacity displays in selected unit in Results; bars/legend will follow in 4.0.
     - Gates: Boundaries.
     - Traceability: PRD Acceptance Criteria (Units toggle); UI Styles; ARCH shared units.
     - Est: 1–2h
 
 - [ ] 4.0 Visualization: Per-GPU stacked bars
-  - [ ] 4.1 Segments per deployment (weights/KV) + reserve/unallocated/free
+  - [ ] 4.1 Segments per deployment (weights/KV) + implied reserve/free
     - Acceptance: Bars reflect per‑GPU aggregator output; segment colors match tokens; small segments collapse labels and show values on hover.
     - Gates: Boundaries; Accessibility basics.
     - Traceability: PRD Visualization; UI Tokens.

--- a/src/app/controller.ts
+++ b/src/app/controller.ts
@@ -1,6 +1,176 @@
 import type { AppState } from './state';
+import type { Deployment, DType, Gpu, KvDType, Model, UnitPreference } from '@shared/types';
+import { listGpus, listModels } from '@data/catalog';
+import { bytesToGB, bytesToGiB } from '@shared/units';
+import { kvBytesPerTokenPerGpu, kvTotalBytesPerGpu, weightBytesPerGpu } from '@domain/memory';
 
-export function recompute(_state: AppState): void {
-  // placeholder
+export function init(state: AppState): void {
+  state.gpuCatalog = listGpus();
+  state.models = listModels();
 }
 
+export function recompute(_state: AppState): void {
+  // aggregation and results will be implemented in 4.x/5.x
+}
+
+export function newDeployment(state: AppState): Deployment {
+  const model = state.models[0] as Model | undefined;
+  const id = `dep_${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    id,
+    modelId: model?.id ?? '',
+    assignedGpuIds: [],
+    tp: 1,
+    weightDtype: (model?.defaultWeightDtype ?? 'bf16') as DType,
+    kvDtype: (model?.defaultKvDtype ?? 'fp16') as KvDType,
+    kvOverheadPct: 0.10,
+    replicationOverheadPct: 0.02,
+    maxModelLen: 4096,
+    maxNumSeqs: 1,
+    utilizationShare: 0.90,
+  };
+}
+
+export function addDeployment(state: AppState): void {
+  state.deployments.push(newDeployment(state));
+}
+
+export function removeDeployment(state: AppState, id: string): void {
+  state.deployments = state.deployments.filter((d) => d.id !== id);
+}
+
+export function setUnit(state: AppState, unit: UnitPreference): void {
+  state.unit = unit;
+  try { localStorage.setItem('unitPreference', unit); } catch {}
+}
+
+export function loadUnitPreference(state: AppState): void {
+  try {
+    const u = localStorage.getItem('unitPreference') as UnitPreference | null;
+    if (u === 'GiB' || u === 'GB') state.unit = u;
+  } catch {}
+}
+
+// Utilization handling has moved to per-deployment. Runtime reserve is implied as 1 - Σ U on each GPU.
+
+export function gpuCapacityLabel(gpu: Gpu): string {
+  const gb = bytesToGB(gpu.vramBytes).toFixed(1);
+  const gib = bytesToGiB(gpu.vramBytes).toFixed(1);
+  return `${gb} GB (${gib} GiB)`;
+}
+
+function makeGpuInstances(type: Gpu, count: number): Gpu[] {
+  const out: Gpu[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push({
+      id: `${type.id}#${i + 1}`,
+      name: `${type.name} #${i + 1}`,
+      vramBytes: type.vramBytes,
+      vendor: type.vendor,
+    });
+  }
+  return out;
+}
+
+function rebuildSelectedGpus(state: AppState): void {
+  const result: Gpu[] = [];
+  for (const t of state.gpuCatalog) {
+    const c = Math.max(0, Math.floor(state.gpuCounts[t.id] ?? 0));
+    if (c > 0) result.push(...makeGpuInstances(t, c));
+  }
+  state.gpus = result;
+  // Clamp/align deployments TP against new selection
+  for (const d of state.deployments) {
+    d.assignedGpuIds = d.assignedGpuIds.filter((id) => state.gpus.some((g) => g.id === id));
+    d.tp = Math.max(1, Math.min(d.tp, d.assignedGpuIds.length || 1));
+  }
+}
+
+export function setGpuCount(state: AppState, typeId: string, count: number): void {
+  state.gpuCounts[typeId] = Math.max(0, Math.floor(Number.isFinite(count) ? count : 0));
+  rebuildSelectedGpus(state);
+}
+
+export function incrementGpu(state: AppState, typeId: string, delta: number): void {
+  const next = Math.max(0, (state.gpuCounts[typeId] ?? 0) + delta);
+  setGpuCount(state, typeId, next);
+}
+
+export function utilizationByGpu(state: AppState): Map<string, number> {
+  // Sum utilization shares across deployments that included the GPU
+  const map = new Map<string, number>();
+  for (const g of state.gpus) map.set(g.id, 0);
+  for (const d of state.deployments) {
+    for (const gid of d.assignedGpuIds) {
+      if (!map.has(gid)) continue;
+      map.set(gid, (map.get(gid) || 0) + (d.utilizationShare || 0));
+    }
+  }
+  return map;
+}
+
+export function impliedReserveByGpu(state: AppState): Map<string, number> {
+  const u = utilizationByGpu(state);
+  const res = new Map<string, number>();
+  for (const [gid, sum] of u.entries()) {
+    res.set(gid, Math.max(0, 1 - sum));
+  }
+  return res;
+}
+
+export function computeResultsStub(state: AppState): Array<{
+  gpuId: string;
+  gpuName: string;
+  capacityBytes: number;
+  utilizationSum: number;
+  impliedReserveFrac: number;
+  usedBytes: number;
+  parts: Array<{ deploymentId: string; modelName: string; weights: number; kv: number }>
+}> {
+  const util = utilizationByGpu(state);
+  const res = impliedReserveByGpu(state);
+  const modelsById = Object.fromEntries(state.models.map(m => [m.id, m] as const)) as Record<string, Model>;
+  const out: Array<{ gpuId: string; gpuName: string; capacityBytes: number; utilizationSum: number; impliedReserveFrac: number; usedBytes: number; parts: Array<{ deploymentId: string; modelName: string; weights: number; kv: number }> }> = [];
+  for (const g of state.gpus) {
+    let used = 0;
+    const parts: Array<{ deploymentId: string; modelName: string; weights: number; kv: number }> = [];
+    for (const d of state.deployments) {
+      if (!d.assignedGpuIds.includes(g.id)) continue;
+      const model = modelsById[d.modelId];
+      if (!model) continue;
+      const tp = Math.max(1, d.assignedGpuIds.length);
+      const weights = weightBytesPerGpu(model.paramsB, d.weightDtype, tp, d.replicationOverheadPct);
+      const perTok = kvBytesPerTokenPerGpu(model.layers, model.hiddenSize, model.heads, model.numKeyValueHeads, d.kvDtype, tp, d.kvOverheadPct);
+      const tokens = d.maxModelLen * d.maxNumSeqs;
+      const kv = kvTotalBytesPerGpu(tokens, perTok);
+      used += weights + kv;
+      parts.push({ deploymentId: d.id, modelName: model.name, weights, kv });
+    }
+    out.push({
+      gpuId: g.id,
+      gpuName: g.name,
+      capacityBytes: g.vramBytes,
+      utilizationSum: util.get(g.id) || 0,
+      impliedReserveFrac: res.get(g.id) || 0,
+      usedBytes: used,
+      parts,
+    });
+  }
+  return out;
+}
+
+export function validateDeployment(d: Deployment, gpus: Gpu[]): { errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const assigned = gpus.filter((g) => d.assignedGpuIds.includes(g.id));
+  if (d.tp > assigned.length) {
+    errors.push('TP must be ≤ number of assigned GPUs');
+  }
+  // mixed capacity warning
+  const caps = Array.from(new Set(assigned.map((g) => g.vramBytes)));
+  if (caps.length > 1 && assigned.length > 0) {
+    warnings.push('Mixed GPU capacities in TP group');
+  }
+  return { errors, warnings };
+}

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -1,7 +1,9 @@
 import type { Deployment, Gpu, Model, UnitPreference } from '@shared/types';
 
 export interface AppState {
-  gpus: Gpu[];
+  gpuCatalog: Gpu[];
+  gpus: Gpu[]; // selected GPU instances
+  gpuCounts: Record<string, number>; // typeId -> count
   models: Model[];
   deployments: Deployment[];
   utilization: number; // U in [0,1]
@@ -11,7 +13,9 @@ export interface AppState {
 
 export function createInitialState(): AppState {
   return {
+    gpuCatalog: [],
     gpus: [],
+    gpuCounts: {},
     models: [],
     deployments: [],
     utilization: 0.9,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -33,5 +33,5 @@ export interface Deployment {
   replicationOverheadPct: number;
   maxModelLen: number;
   maxNumSeqs: number;
+  utilizationShare?: number; // fraction [0..1] of per-GPU capacity allocated to this deployment
 }
-

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -10,3 +10,15 @@
     color: var(--color-text);
   }
 }
+
+/* Provide semantic color utilities backed by CSS variables.
+   This ensures buttons like bg-primary are visible even if Tailwind
+   doesn't generate custom color classes in this environment. */
+@layer utilities {
+  .bg-bg { background-color: var(--color-bg); }
+  .bg-surface { background-color: var(--color-surface); }
+  .text-text { color: var(--color-text); }
+  .text-muted { color: var(--color-muted); }
+  .bg-primary { background-color: var(--color-primary); }
+  .text-primary { color: var(--color-primary); }
+}

--- a/src/ui/DeploymentList.vue
+++ b/src/ui/DeploymentList.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="space-y-3">
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold">Deployments</h2>
+      <button class="px-3 py-1.5 rounded bg-primary text-white" @click="$emit('add')">Add Deployment</button>
+    </div>
+    <div v-if="state.deployments.length === 0" class="text-muted">No deployments yet. Click “Add Deployment”.</div>
+    <div v-for="d in state.deployments" :key="d.id" class="border border-muted/30 rounded-md p-3 bg-surface">
+      <div class="flex items-start justify-between">
+        <div class="font-medium">{{ modelName(d.modelId) || 'Select model' }}</div>
+        <button class="text-sm text-danger" @click="$emit('remove', d.id)">Remove</button>
+      </div>
+
+      <div class="grid md:grid-cols-3 gap-3 mt-3">
+        <div>
+          <label class="block text-sm text-muted">Model</label>
+          <select class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" :value="d.modelId" @change="onModelChange(d, $event)">
+            <option v-for="m in state.models" :key="m.id" :value="m.id">{{ m.name }}</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm text-muted">Assign GPUs</label>
+          <div class="mt-1 max-h-36 overflow-auto border border-muted/30 rounded p-2 space-y-1">
+            <label v-for="g in state.gpus" :key="g.id" class="flex items-center gap-2">
+              <input type="checkbox" :value="g.id" :checked="d.assignedGpuIds.includes(g.id)" @change="onGpuToggle(d, g.id, $event)" />
+              <span>{{ g.name }} — {{ gpuLabel(g) }}</span>
+            </label>
+          </div>
+        </div>
+        <div>
+          <label class="block text-sm text-muted">TP</label>
+          <input class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="1" step="1" :value="d.tp" @input="onField(d, 'tp', $event)" />
+        </div>
+        <div>
+          <label class="block text-sm text-muted">Weight dtype</label>
+          <select class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" :value="d.weightDtype" @change="onField(d, 'weightDtype', $event)">
+            <option value="bf16">bf16</option>
+            <option value="fp16">fp16</option>
+            <option value="fp32">fp32</option>
+            <option value="q8">q8</option>
+            <option value="q4">q4</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm text-muted">KV dtype</label>
+          <select class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" :value="d.kvDtype" @change="onField(d, 'kvDtype', $event)">
+            <option value="bf16">bf16</option>
+            <option value="fp16">fp16</option>
+            <option value="fp8">fp8</option>
+            <option value="int8">int8</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm text-muted">KV overhead %</label>
+          <input class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="0" step="1" :value="Math.round(d.kvOverheadPct*100)" @input="onPct(d, 'kvOverheadPct', $event)" />
+        </div>
+        <div>
+          <label class="block text-sm text-muted">Replication overhead %</label>
+          <input class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="0" step="1" :value="Math.round(d.replicationOverheadPct*100)" @input="onPct(d, 'replicationOverheadPct', $event)" />
+        </div>
+        <div>
+          <label class="block text-sm text-muted">max_model_len</label>
+          <input class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="0" step="128" :value="d.maxModelLen" @input="onField(d, 'maxModelLen', $event)" />
+        </div>
+        <div>
+          <label class="block text-sm text-muted">max_num_seqs</label>
+          <input class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="1" step="1" :value="d.maxNumSeqs" @input="onField(d, 'maxNumSeqs', $event)" />
+        </div>
+      </div>
+
+      <div class="mt-3">
+        <div v-if="errors(d).length" class="text-danger text-sm">{{ errors(d).join('; ') }}</div>
+        <div v-else-if="warnings(d).length" class="text-warning text-sm">{{ warnings(d).join('; ') }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AppState } from '@app/state'
+import { validateDeployment, gpuCapacityLabel } from '@app/controller'
+
+type Deployment = AppState['deployments'][number]
+type Gpu = AppState['gpus'][number]
+
+const props = defineProps<{ state: AppState }>()
+defineEmits<{ add: []; remove: [id: string] }>()
+
+function modelName(id: string): string|undefined {
+  return props.state.models.find(m => m.id === id)?.name
+}
+function onModelChange(d: Deployment, e: Event) {
+  d.modelId = (e.target as HTMLSelectElement).value
+  const model = props.state.models.find(m => m.id === d.modelId)
+  if (model) {
+    d.weightDtype = model.defaultWeightDtype
+    d.kvDtype = model.defaultKvDtype
+  }
+}
+function onGpuToggle(d: Deployment, id: string, e: Event) {
+  const checked = (e.target as HTMLInputElement).checked
+  const set = new Set(d.assignedGpuIds)
+  if (checked) set.add(id)
+  else set.delete(id)
+  d.assignedGpuIds = Array.from(set)
+  // auto-align TP with number of assigned GPUs as requested
+  d.tp = Math.max(1, d.assignedGpuIds.length)
+}
+function onField<T extends keyof Deployment>(d: Deployment, key: T, e: Event) {
+  const el = e.target as HTMLInputElement | HTMLSelectElement
+  const v = el instanceof HTMLInputElement && el.type === 'number' ? Number(el.value) : (el as HTMLSelectElement).value
+  // @ts-expect-error generic assignment
+  d[key] = v
+  if (key === 'tp') {
+    const max = d.assignedGpuIds.length || 1
+    d.tp = Math.max(1, Math.min(d.tp, max))
+  }
+}
+function onPct<T extends 'kvOverheadPct'|'replicationOverheadPct'>(d: Deployment, key: T, e: Event) {
+  const v = Math.max(0, Number((e.target as HTMLInputElement).value) || 0) / 100
+  d[key] = v
+}
+function gpuLabel(g: Gpu) { return gpuCapacityLabel(g) }
+function errors(d: Deployment) { return validateDeployment(d, props.state.gpus).errors }
+function warnings(d: Deployment) { return validateDeployment(d, props.state.gpus).warnings }
+</script>
+
+<style scoped>
+.text-danger { color: #dc2626; }
+.text-warning { color: #b45309; }
+</style>

--- a/src/ui/DeploymentModels.vue
+++ b/src/ui/DeploymentModels.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="bg-surface border border-muted/30 rounded-md p-4 space-y-3">
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold">Select Models</h2>
+      <button class="px-3 py-1.5 rounded bg-primary text-white" @click="$emit('add')">Add Deployment</button>
+    </div>
+    <div v-if="state.deployments.length === 0" class="text-muted">No deployments yet. Click “Add Deployment”.</div>
+    <div v-for="d in state.deployments" :key="d.id" class="border border-muted/30 rounded p-3">
+      <div class="flex items-center justify-between">
+        <div class="font-medium">Deployment: {{ d.id }}</div>
+        <button class="text-sm text-danger" @click="$emit('remove', d.id)">Remove</button>
+      </div>
+      <div class="grid md:grid-cols-3 gap-3 mt-3">
+        <div>
+          <label class="block text-sm text-muted">Model</label>
+          <select class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" :value="d.modelId" @change="onModelChange(d, $event)">
+            <option v-for="m in state.models" :key="m.id" :value="m.id">{{ m.name }}</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm text-muted">Utilization U [0..1]</label>
+          <input class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="0" max="1" step="0.01" :value="d.utilizationShare" @input="onUChange(d, $event)" />
+        </div>
+        <div class="self-end text-sm text-muted">Selected GPUs: {{ state.gpus.length }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AppState } from '@app/state'
+
+const props = defineProps<{ state: AppState }>()
+defineEmits<{ add: []; remove: [id: string] }>()
+
+function onModelChange(d: AppState['deployments'][number], e: Event) {
+  const id = (e.target as HTMLSelectElement).value
+  d.modelId = id
+  const model = props.state.models.find(m => m.id === id)
+  if (model) {
+    d.weightDtype = model.defaultWeightDtype
+    d.kvDtype = model.defaultKvDtype
+  }
+}
+function onUChange(d: AppState['deployments'][number], e: Event) {
+  const v = Math.max(0, Math.min(1, parseFloat((e.target as HTMLInputElement).value)))
+  d.utilizationShare = Number.isFinite(v) ? v : 0
+}
+</script>
+
+<style scoped>
+.text-danger { color: #dc2626; }
+</style>

--- a/src/ui/DeploymentWorkload.vue
+++ b/src/ui/DeploymentWorkload.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="bg-surface border border-muted/30 rounded-md p-4 space-y-3">
+    <h2 class="text-lg font-semibold">Configure Workload</h2>
+    <div v-if="state.deployments.length === 0" class="text-muted">No deployments defined. Go back and add a model.</div>
+    <div v-for="d in state.deployments" :key="d.id" class="border border-muted/30 rounded p-3">
+      <div class="font-medium mb-2">{{ modelName(d.modelId) || 'Select model' }}</div>
+      <div class="grid md:grid-cols-3 gap-3">
+        <div class="md:col-span-1">
+          <label class="block text-sm text-muted">Assign GPUs</label>
+          <div class="mt-1 max-h-40 overflow-auto border border-muted/30 rounded p-2 space-y-1">
+            <label v-for="g in state.gpus" :key="g.id" class="flex items-center gap-2">
+              <input type="checkbox" :value="g.id" :checked="d.assignedGpuIds.includes(g.id)" @change="onGpuToggle(d, g.id, $event)" />
+              <span>{{ g.name }}</span>
+            </label>
+          </div>
+          <div class="mt-2 text-sm">TP: <span class="font-medium">{{ d.assignedGpuIds.length }}</span></div>
+        </div>
+        <div>
+          <label class="block text-sm text-muted">Weight dtype</label>
+          <select class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" :value="d.weightDtype" @change="onField(d, 'weightDtype', $event)">
+            <option value="bf16">bf16</option>
+            <option value="fp16">fp16</option>
+            <option value="fp32">fp32</option>
+            <option value="q8">q8</option>
+            <option value="q4">q4</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm text-muted">KV dtype</label>
+          <select class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" :value="d.kvDtype" @change="onField(d, 'kvDtype', $event)">
+            <option value="bf16">bf16</option>
+            <option value="fp16">fp16</option>
+            <option value="fp8">fp8</option>
+            <option value="int8">int8</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm text-muted">KV overhead %</label>
+          <input class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="0" step="1" :value="Math.round(d.kvOverheadPct*100)" @input="onPct(d, 'kvOverheadPct', $event)" />
+        </div>
+        <div>
+          <label class="block text-sm text-muted">Replication overhead %</label>
+          <input class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="0" step="1" :value="Math.round(d.replicationOverheadPct*100)" @input="onPct(d, 'replicationOverheadPct', $event)" />
+        </div>
+        <div>
+          <label class="block text-sm text-muted">max_model_len</label>
+          <input class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="0" step="128" :value="d.maxModelLen" @input="onField(d, 'maxModelLen', $event)" />
+        </div>
+        <div>
+          <label class="block text-sm text-muted">max_num_seqs</label>
+          <input class="mt-1 w-full px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="1" step="1" :value="d.maxNumSeqs" @input="onField(d, 'maxNumSeqs', $event)" />
+        </div>
+      </div>
+      <div class="mt-3">
+        <div v-if="errors(d).length" class="text-danger text-sm">{{ errors(d).join('; ') }}</div>
+        <div v-else-if="warnings(d).length" class="text-warning text-sm">{{ warnings(d).join('; ') }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AppState } from '@app/state'
+import { validateDeployment } from '@app/controller'
+
+const props = defineProps<{ state: AppState }>()
+
+function modelName(id: string) {
+  return props.state.models.find(m => m.id === id)?.name
+}
+function onField<T extends keyof AppState['deployments'][number]>(d: AppState['deployments'][number], key: T, e: Event) {
+  const el = e.target as HTMLInputElement | HTMLSelectElement
+  const v = el instanceof HTMLInputElement && el.type === 'number' ? Number(el.value) : (el as HTMLSelectElement).value
+  // @ts-expect-error generic assignment
+  d[key] = v
+}
+function onPct<T extends 'kvOverheadPct'|'replicationOverheadPct'>(d: AppState['deployments'][number], key: T, e: Event) {
+  const v = Math.max(0, Number((e.target as HTMLInputElement).value) || 0) / 100
+  d[key] = v
+}
+function onGpuToggle(d: AppState['deployments'][number], id: string, e: Event) {
+  const checked = (e.target as HTMLInputElement).checked
+  const set = new Set(d.assignedGpuIds)
+  if (checked) set.add(id)
+  else set.delete(id)
+  d.assignedGpuIds = Array.from(set)
+  d.tp = Math.max(1, d.assignedGpuIds.length)
+}
+function errors(d: AppState['deployments'][number]) { return validateDeployment(d, props.state.gpus).errors }
+function warnings(d: AppState['deployments'][number]) { return validateDeployment(d, props.state.gpus).warnings }
+</script>
+
+<style scoped>
+.text-danger { color: #dc2626; }
+.text-warning { color: #b45309; }
+</style>
+

--- a/src/ui/GlobalControls.vue
+++ b/src/ui/GlobalControls.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="bg-surface border border-muted/30 rounded-md p-4 flex flex-wrap gap-4 items-end">
+    <div>
+      <label class="block text-sm text-muted">Units</label>
+      <select class="mt-1 px-2 py-1 bg-bg border border-muted/30 rounded" :value="state.unit" @change="onUnitChange($event)">
+        <option value="GiB">GiB</option>
+        <option value="GB">GB</option>
+      </select>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AppState } from '@app/state'
+import { setUnit } from '@app/controller'
+
+const props = defineProps<{ state: AppState }>()
+
+function onUnitChange(e: Event) {
+  const v = (e.target as HTMLSelectElement).value as 'GiB'|'GB'
+  setUnit(props.state, v)
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/ui/GpuSelector.vue
+++ b/src/ui/GpuSelector.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="bg-surface border border-muted/30 rounded-md p-4">
+    <h2 class="text-lg font-semibold">Select GPUs</h2>
+    <div class="mt-3 grid md:grid-cols-2 lg:grid-cols-3 gap-3">
+      <div v-for="t in state.gpuCatalog" :key="t.id" class="border border-muted/30 rounded p-3">
+        <div class="font-medium">{{ t.name }}</div>
+        <div class="text-sm text-muted">{{ capacity(t) }}</div>
+        <div class="mt-2 flex items-center gap-2">
+          <button class="px-2 py-1 rounded bg-surface border border-muted/30" @click="dec(t.id)">-</button>
+          <input class="w-16 px-2 py-1 bg-bg border border-muted/30 rounded" type="number" min="0" step="1" :value="count(t.id)" @input="onCount(t.id, $event)" />
+          <button class="px-2 py-1 rounded bg-surface border border-muted/30" @click="inc(t.id)">+</button>
+        </div>
+      </div>
+    </div>
+    <div class="mt-3 text-sm text-muted">Selected: {{ totalSelected }} GPU(s)</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AppState } from '@app/state'
+import { gpuCapacityLabel, incrementGpu, setGpuCount } from '@app/controller'
+import { computed } from 'vue'
+
+const props = defineProps<{ state: AppState }>()
+
+function capacity(t: AppState['gpuCatalog'][number]) {
+  return gpuCapacityLabel(t)
+}
+function count(id: string) {
+  return props.state.gpuCounts[id] ?? 0
+}
+function inc(id: string) { incrementGpu(props.state, id, +1) }
+function dec(id: string) { incrementGpu(props.state, id, -1) }
+function onCount(id: string, e: Event) {
+  const v = parseInt((e.target as HTMLInputElement).value, 10)
+  setGpuCount(props.state, id, isNaN(v) ? 0 : v)
+}
+
+const totalSelected = computed(() => props.state.gpus.length)
+</script>
+
+<style scoped></style>
+

--- a/src/ui/ResultsStub.vue
+++ b/src/ui/ResultsStub.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="space-y-4">
+    <div class="bg-surface border border-muted/30 rounded-md p-4">
+      <h2 class="text-lg font-semibold">Selected GPUs</h2>
+      <div v-if="state.gpus.length === 0" class="text-muted mt-2">No GPUs selected.</div>
+      <ul v-else class="mt-2 grid md:grid-cols-2 lg:grid-cols-3 gap-2">
+        <li v-for="r in results" :key="r.gpuId" class="border border-muted/30 rounded p-2">
+          <div class="flex items-center justify-between">
+            <span>{{ r.gpuName }}</span>
+            <span class="text-sm text-muted">{{ format(r.capacityBytes) }}</span>
+          </div>
+          <div class="mt-1 text-sm">
+            <span class="text-muted">ΣU:</span> <span class="font-medium">{{ r.util.toFixed(2) }}</span>
+            <span class="ml-3 text-muted">Implied reserve:</span> <span class="font-medium">{{ (r.reserve * 100).toFixed(0) }}%</span>
+            <span v-if="r.util > 1" class="ml-2 text-danger">over 100%</span>
+          </div>
+          <div class="mt-1 text-sm">
+            <span class="text-muted">Approx used (weights+KV):</span>
+            <span class="font-medium">{{ format(r.used) }} ({{ ((r.used / r.capacityBytes) * 100).toFixed(0) }}%)</span>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <div class="bg-surface border border-muted/30 rounded-md p-4">
+      <h2 class="text-lg font-semibold">Deployments</h2>
+      <div v-if="state.deployments.length === 0" class="text-muted mt-2">No deployments configured.</div>
+      <div v-for="d in state.deployments" :key="d.id" class="mt-3 border border-muted/30 rounded p-3">
+        <div class="flex items-center justify-between">
+          <div class="font-medium">{{ modelName(d.modelId) || 'Select model' }}</div>
+          <div class="text-sm text-muted">Deployment: {{ d.id }}</div>
+        </div>
+        <div class="mt-2 grid md:grid-cols-3 gap-2 text-sm">
+          <div><span class="text-muted">Assigned GPUs:</span> <span class="font-medium">{{ d.assignedGpuIds.length }}</span></div>
+          <div><span class="text-muted">TP:</span> <span class="font-medium">{{ d.assignedGpuIds.length }}</span></div>
+          <div><span class="text-muted">U share:</span> <span class="font-medium">{{ (uShare(d) * 100).toFixed(0) }}%</span></div>
+          <div><span class="text-muted">Workload:</span> <span class="font-medium">{{ d.maxNumSeqs }} seq × {{ d.maxModelLen }} tokens</span></div>
+          <div><span class="text-muted">DTypes:</span> <span class="font-medium">weights={{ d.weightDtype }}, kv={{ d.kvDtype }}</span></div>
+          <div><span class="text-muted">Overheads:</span> <span class="font-medium">rep={{ pct(d.replicationOverheadPct) }}, kv={{ pct(d.kvOverheadPct) }}</span></div>
+          <div class="md:col-span-3">
+            <span class="text-muted">GPU list:</span>
+            <span class="font-medium">{{ assignedGpuNames(d).join(', ') || '—' }}</span>
+          </div>
+        </div>
+        <div class="mt-2 text-sm">
+          <span v-if="errors(d).length" class="text-danger">{{ errors(d).join('; ') }}</span>
+          <span v-else-if="warnings(d).length" class="text-warning">{{ warnings(d).join('; ') }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AppState } from '@app/state'
+import { validateDeployment, utilizationByGpu, impliedReserveByGpu, computeResultsStub } from '@app/controller'
+import { formatBytes } from '@shared/units'
+import { computed } from 'vue'
+
+const props = defineProps<{ state: AppState }>()
+const util = Object.fromEntries(utilizationByGpu(props.state).entries()) as Record<string, number>
+const res = Object.fromEntries(impliedReserveByGpu(props.state).entries()) as Record<string, number>
+const results = computed(() => computeResultsStub(props.state).map(r => ({
+  gpuId: r.gpuId,
+  gpuName: r.gpuName,
+  capacityBytes: r.capacityBytes,
+  used: r.usedBytes,
+  util: r.utilizationSum,
+  reserve: r.impliedReserveFrac,
+})))
+function format(bytes: number) { return formatBytes(bytes, props.state.unit, 1) }
+
+function capacity(g: AppState['gpus'][number]) { return formatBytes(g.vramBytes, props.state.unit, 1) }
+function modelName(id: string) { return props.state.models.find(m => m.id === id)?.name }
+function pct(v: number) { return `${Math.round((v || 0) * 100)}%` }
+function assignedGpuNames(d: AppState['deployments'][number]) {
+  const byId = new Map(props.state.gpus.map(g => [g.id, g.name] as const))
+  return d.assignedGpuIds.map(id => byId.get(id)).filter(Boolean) as string[]
+}
+function errors(d: AppState['deployments'][number]) { return validateDeployment(d, props.state.gpus).errors }
+function warnings(d: AppState['deployments'][number]) { return validateDeployment(d, props.state.gpus).warnings }
+function uShare(d: AppState['deployments'][number]) { return d.utilizationShare ?? 0 }
+</script>
+
+<style scoped>
+.text-danger { color: #dc2626; }
+.text-warning { color: #b45309; }
+.text-muted { color: #6b7280; }
+</style>

--- a/src/ui/Stepper.vue
+++ b/src/ui/Stepper.vue
@@ -1,0 +1,16 @@
+<template>
+  <ol class="flex gap-2 text-sm">
+    <li v-for="(s, i) in steps" :key="i" class="flex items-center gap-2">
+      <span :class="['w-6 h-6 rounded-full flex items-center justify-center', i === current ? 'bg-primary text-white' : 'bg-surface border border-muted/30']">{{ i+1 }}</span>
+      <span :class="[i === current ? 'font-medium' : 'text-muted']">{{ s }}</span>
+      <span v-if="i < steps.length -1" class="mx-2 text-muted">›</span>
+    </li>
+  </ol>
+</template>
+
+<script setup lang="ts">
+defineProps<{ steps: string[]; current: number }>()
+</script>
+
+<style scoped></style>
+


### PR DESCRIPTION
This pull request introduces a new per-deployment GPU utilization share model, replacing the previous global utilization and fixed reserve approach. The changes update the architecture, requirements, and tasks documentation to reflect this new model, and update the application UI flow to support stepwise configuration and validation of deployments, workloads, and results. The most important changes are:

**Architecture & Domain Model Updates:**
* Added ADR-0005, which formalizes the decision to use per-deployment utilization shares (`utilizationShare ∈ [0,1]`) and compute implied reserves per GPU as `max(0, 1 − Σ U_d)`. The global utilization and fixed reserve UI are removed.
* Updated the `Deployment` type in `src/shared/types.ts` to include an optional `utilizationShare` property, and revised documentation to consistently reference new file locations and schema.
* Adjusted data flow and formulas throughout the architecture and PRD to use per-deployment utilization shares, including validation and error/warning logic when overallocation occurs. [[1]](diffhunk://#diff-97686b58786a06687b2d34ccc1a4f6a399bc362ded1e026cabd8ca7ddc5f0bddL14-R14) [[2]](diffhunk://#diff-97686b58786a06687b2d34ccc1a4f6a399bc362ded1e026cabd8ca7ddc5f0bddL29-R29) [[3]](diffhunk://#diff-97686b58786a06687b2d34ccc1a4f6a399bc362ded1e026cabd8ca7ddc5f0bddL42-R53) [[4]](diffhunk://#diff-97686b58786a06687b2d34ccc1a4f6a399bc362ded1e026cabd8ca7ddc5f0bddL217-R218) [[5]](diffhunk://#diff-97686b58786a06687b2d34ccc1a4f6a399bc362ded1e026cabd8ca7ddc5f0bddL249-R252) [[6]](diffhunk://#diff-97686b58786a06687b2d34ccc1a4f6a399bc362ded1e026cabd8ca7ddc5f0bddL276-R276)

**UI & Application Flow:**
* Refactored the main `App.vue` to implement a stepper-based UI flow: GPU selection, model selection (with per-deployment utilization shares), workload configuration, and results. Added new components for each step and improved navigation and validation logic.

**Tasks & Implementation Tracking:**
* Updated the implementation tasks to reflect the new per-deployment utilization share model, marking steps related to global utilization and reserve as replaced/complete, and adding acceptance criteria for per-deployment controls and implied reserve display. [[1]](diffhunk://#diff-183c70022fe4e279f7f96b3c8e6b4bdbfb86f4f4b1e5cf408620679013b2eab8L67-R67) [[2]](diffhunk://#diff-183c70022fe4e279f7f96b3c8e6b4bdbfb86f4f4b1e5cf408620679013b2eab8L78-R101)