### PR TITLE
feat: Implement GPU visualization components and update task list

### DIFF
--- a/docs/tasks/llm-gpu-calc/v1/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v1/tasks.md
@@ -97,23 +97,23 @@
     - Traceability: PRD Acceptance Criteria (Units toggle); UI Styles; ARCH shared units.
     - Est: 1–2h
 
-- [ ] 4.0 Visualization: Per-GPU stacked bars
-  - [ ] 4.1 Segments per deployment (weights/KV) + implied reserve/free
+- [x] 4.0 Visualization: Per-GPU stacked bars
+  - [x] 4.1 Segments per deployment (weights/KV) + implied reserve/free
     - Acceptance: Bars reflect per‑GPU aggregator output; segment colors match tokens; small segments collapse labels and show values on hover.
     - Gates: Boundaries; Accessibility basics.
     - Traceability: PRD Visualization; UI Tokens.
     - Est: 2–3h
-  - [ ] 4.2 Legend and bar labels with selected unit (GiB/GB) and %
+  - [x] 4.2 Legend and bar labels with selected unit (GiB/GB) and %
     - Acceptance: Legend entries map to segments; labels formatted with 1 decimal and selected unit; percent displayed.
     - Gates: Boundaries; Formatting consistency.
     - Traceability: PRD UI Styles (number formatting).
     - Est: 1–2h
-  - [ ] 4.3 Apply Tailwind utilities and tokens for consistent styling; dark mode variant
+  - [x] 4.3 Apply Tailwind utilities and tokens for consistent styling; dark mode variant
     - Acceptance: Components use Tailwind with semantic token classes/vars; dark mode supported via `.dark`.
     - Gates: Dependency (already configured); Accessibility contrast.
     - Traceability: ADR‑0003; PRD UI Tokens.
     - Est: 1–2h
-  - [ ] 4.4 Re-render bars/legend on unit change; tooltips/aria-labels show precise values
+  - [x] 4.4 Re-render bars/legend on unit change; tooltips/aria-labels show precise values
     - Acceptance: Unit toggle triggers re-render; aria-label summarizes segments; tooltip shows exact bytes + formatted values.
     - Gates: Accessibility; Boundaries.
     - Traceability: PRD UI Styles; ARCH Shared utils.

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,6 +23,8 @@
       <div v-else class="space-y-4">
         <GlobalControls :state="state" />
         <ResultsStub :state="state" />
+        <Legend />
+        <PerGpuBars :state="state" />
       </div>
       <div class="flex items-center justify-between pt-2">
         <button class="px-3 py-1.5 rounded bg-surface border border-muted/30" :disabled="currentStep === 0" @click="prev">Back</button>
@@ -38,6 +40,8 @@ import GlobalControls from '@ui/GlobalControls.vue'
 import DeploymentModels from '@ui/DeploymentModels.vue'
 import DeploymentWorkload from '@ui/DeploymentWorkload.vue'
 import ResultsStub from '@ui/ResultsStub.vue'
+import PerGpuBars from '@ui/PerGpuBars.vue'
+import Legend from '@ui/Legend.vue'
 import Stepper from '@ui/Stepper.vue'
 import GpuSelector from '@ui/GpuSelector.vue'
 import { createInitialState } from '@app/state'

--- a/src/ui/Legend.vue
+++ b/src/ui/Legend.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="flex flex-wrap gap-3 text-sm">
+    <div v-for="item in items" :key="item.key" class="flex items-center gap-2">
+      <span class="inline-block w-3 h-3 rounded" :style="{ backgroundColor: item.color }" />
+      <span class="text-muted">{{ item.label }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const items = [
+  { key: 'weights', label: 'Weights', color: 'var(--color-weights)' },
+  { key: 'kv', label: 'KV Cache', color: 'var(--color-kv)' },
+  { key: 'reserve', label: 'Implied Reserve', color: 'var(--color-reserve)' },
+  { key: 'free', label: 'Free', color: 'var(--color-free)' },
+]
+</script>
+
+<style scoped></style>
+


### PR DESCRIPTION
This pull request implements the per-GPU stacked bar visualization for GPU memory usage, along with a legend and accessibility improvements. The main changes include adding new UI components (`PerGpuBars` and `Legend`), updating the controller logic to compute per-GPU bar data, and wiring these components into the main application view.

**Visualization and UI Enhancements:**

* Added new `PerGpuBars` Vue component to display per-GPU stacked bars showing segments for weights, KV cache, implied reserve, and free memory, with tooltips and keyboard accessibility. (`src/ui/PerGpuBars.vue`)
* Added new `Legend` Vue component to display color-coded labels for each segment type in the stacked bar visualization. (`src/ui/Legend.vue`)
* Wired `PerGpuBars` and `Legend` components into the main application view so they are rendered alongside results. (`src/App.vue`) [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R26-R27) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R43-R44)

**Controller and Data Logic:**

* Added `buildPerGpuBars` function to the controller to generate per-GPU bar data structure, including segment breakdowns for each GPU. (`src/app/controller.ts`)

**Documentation and Task Tracking:**

* Updated the project task checklist to mark the per-GPU stacked bar visualization and related sub-tasks as complete. (`docs/tasks/llm-gpu-calc/v1/tasks.md`)