### PR TITLE
Update docs for versioning & releasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,32 @@ Vite base path for Pages:
 Deployment URL:
 
 - For project pages: `https://jacoblindev.github.io/llm-gpu-calc/`
+
+## Versioning & Releases (v1)
+
+- Policy: SemVer app version in `package.json`; tags `vX.Y.Z`; Pages deploys on every push to `main`.
+- Branching: Trunk‑based on `main` with short‑lived feature branches via PR. `develop` is optional; if used, merge `main` → `develop` after releases.
+
+GitHub UI flow (no local CLI required):
+
+1) Bump the version
+   - Open `package.json` in the web UI → Edit `version` → propose changes to a new branch → open PR to `main`.
+   - Wait for CI to pass, then merge into `main`.
+
+2) Tag the release
+   - Go to Releases → “Draft a new release”.
+   - Choose a tag → “Create new tag” (e.g., `v1.0.1`) targeting the merge commit on `main` → Publish.
+
+3) Deploy
+   - Pages deployment runs automatically on `main`; no extra steps.
+
+4) Optional: keep `develop` in sync
+   - Open a PR `main` → `develop` and merge.
+
+CLI alternative (equivalent):
+
+```sh
+# from a clean main
+npm version patch   # or minor|major
+git push --follow-tags
+```

--- a/docs/adr/ADR-0006-versioning-and-releases.md
+++ b/docs/adr/ADR-0006-versioning-and-releases.md
@@ -17,6 +17,7 @@ This project is a simple SPA (Vue + Vite) deployed to GitHub Pages with no backe
 - Git tags: Tag releases as `vX.Y.Z` (created by `npm version` or manually). Tags provide traceability; GitHub Releases are optional.
 - Deployments: Keep Pages deployments on every push to `main` (current workflow). Tags are for traceability, not gating deploys in v1.
 - Pre‑releases: If needed, use `-rc.N` (e.g., `1.2.0-rc.1`). Pages continues to deploy `main`; no separate channels.
+- Branching: Trunk‑based on `main`. Use short‑lived feature branches via PRs into `main`. A long‑lived `develop` branch is not required; if present, synchronize it by merging `main` back after a release to avoid version drift.
 - Stamping (optional, simple): Expose build info in the UI using Vite envs:
   - `VITE_APP_VERSION = npm_package_version`
   - `VITE_APP_COMMIT = $GITHUB_SHA` (first 7 chars shown)
@@ -40,6 +41,21 @@ This project is a simple SPA (Vue + Vite) deployed to GitHub Pages with no backe
   npm version patch
   git push --follow-tags
   ```
+
+- Manual flow via GitHub UI (no local CLI required):
+
+  1) Bump version in `package.json` via PR to `main`:
+     - Navigate to `package.json` → Edit (pencil) → update the `version`.
+     - Propose changes to a new branch and open a PR targeting `main`.
+     - Let CI pass (typecheck/tests) and merge the PR into `main`.
+  2) Create an annotated tag and (optional) Release:
+     - Go to GitHub → Releases → “Draft a new release”.
+     - Choose a tag → “Create new tag” `vX.Y.Z`; target the merge commit on `main`.
+     - Publish. (This creates the tag; Release notes are optional in v1.)
+  3) Deployment:
+     - Pages deployment runs automatically on push to `main` and will already have built the merged commit.
+  4) If using a `develop` branch (optional):
+     - Open a PR from `main` → `develop` and merge to keep branches in sync.
 
 - Optional stamping in CI (deploy workflow):
 

--- a/docs/adr/ADR-0006-versioning-and-releases.md
+++ b/docs/adr/ADR-0006-versioning-and-releases.md
@@ -1,0 +1,58 @@
+# ADR-0006: Versioning and Release Policy (v1)
+
+Date: 2025-09-08
+
+## Status
+
+Accepted
+
+## Context
+
+This project is a simple SPA (Vue + Vite) deployed to GitHub Pages with no backend in v1. We want a predictable but minimal versioning and release process that does not add tooling or complexity.
+
+## Decision
+
+- App version: Use Semantic Versioning `MAJOR.MINOR.PATCH` for the web app.
+- Source of truth: `package.json#version`. Bump via `npm version patch|minor|major`.
+- Git tags: Tag releases as `vX.Y.Z` (created by `npm version` or manually). Tags provide traceability; GitHub Releases are optional.
+- Deployments: Keep Pages deployments on every push to `main` (current workflow). Tags are for traceability, not gating deploys in v1.
+- Pre‑releases: If needed, use `-rc.N` (e.g., `1.2.0-rc.1`). Pages continues to deploy `main`; no separate channels.
+- Stamping (optional, simple): Expose build info in the UI using Vite envs:
+  - `VITE_APP_VERSION = npm_package_version`
+  - `VITE_APP_COMMIT = $GITHUB_SHA` (first 7 chars shown)
+  These can be displayed in a small footer/About dialog. Implementation can land as a separate small task.
+- Changelog: Keep it lightweight. Summarize notable changes in PR descriptions and Git tags; a generated `CHANGELOG.md` is not required in v1.
+- Data/catalog changes: Adding or correcting entries is a PATCH. Schema changes (e.g., new required fields) are MINOR; breaking JSON shape changes (removing/renaming fields) are MAJOR.
+- Docs versioning: Continue using `docs/prd/<slug>/vN`, `ARCH-vN.md`, and ADRs. On meaningful scope/boundary changes, bump to the next `vN` for docs.
+
+## Consequences
+
+- Minimal overhead: No new tooling (e.g., semantic‑release) or complex branching.
+- Clear traceability: `package.json` and tags align; Pages always serves the latest `main` build.
+- Easy support: Version and short commit shown in the UI (once stamping is wired) aid bug reports.
+
+## Implementation Notes
+
+- Bump and tag:
+
+  ```sh
+  # patch/minor/major as appropriate
+  npm version patch
+  git push --follow-tags
+  ```
+
+- Optional stamping in CI (deploy workflow):
+
+  ```yaml
+  env:
+    VITE_APP_VERSION: ${{ vars.APP_VERSION || steps.pkg.outputs.version }}
+    VITE_APP_COMMIT: ${{ github.sha }}
+  ```
+
+  Or rely on Vite reading `process.env.npm_package_version` directly for `VITE_APP_VERSION`.
+
+## Alternatives Considered
+
+- CalVer (`YYYY.MM.PATCH`): nice for steady cadence, but SemVer is familiar and sufficient here.
+- Release‑only deployments: gating Pages deploys by tags adds friction; deferred unless needed.
+- Full automation (semantic‑release): powerful but heavier than needed for v1.

--- a/docs/architecture/ARCH-v1.md
+++ b/docs/architecture/ARCH-v1.md
@@ -84,6 +84,11 @@ State lives in App. Domain is stateless. Data is static JSON read at startup.
 - App version: SemVer `MAJOR.MINOR.PATCH`.
 - Source of truth: `package.json#version`; bump with `npm version {patch|minor|major}`.
 - Tags: Create Git tag `vX.Y.Z` for each release; use tags for traceability. Pages continues to deploy on `main`.
+- Branching: Trunk‑based on `main` with short‑lived feature branches merged via PR. A `develop` branch is optional; if it exists, merge `main` back into `develop` after releases to keep versions aligned.
+- Manual UI flow (supported):
+  - Bump `package.json#version` via a PR in the GitHub UI → merge to `main` (CI validates).
+  - Draft a Release in the GitHub UI and create tag `vX.Y.Z` targeting the merge commit on `main`.
+  - Pages deploy runs automatically on `main`.
 - Stamping (optional): Expose `VITE_APP_VERSION` and `VITE_APP_COMMIT` via Vite/env and display in a small footer/About. No backend.
 - Catalog changes: Data additions/edits are PATCH; schema additions MINOR; breaking schema changes MAJOR.
 - See ADR-0006 for details.

--- a/docs/architecture/ARCH-v1.md
+++ b/docs/architecture/ARCH-v1.md
@@ -79,6 +79,15 @@ State lives in App. Domain is stateless. Data is static JSON read at startup.
   - Pages: Source = GitHub Actions; Environment = `github-pages`.
   - Branch protection (recommended): require CI checks on `main`.
 
+### Versioning (v1)
+
+- App version: SemVer `MAJOR.MINOR.PATCH`.
+- Source of truth: `package.json#version`; bump with `npm version {patch|minor|major}`.
+- Tags: Create Git tag `vX.Y.Z` for each release; use tags for traceability. Pages continues to deploy on `main`.
+- Stamping (optional): Expose `VITE_APP_VERSION` and `VITE_APP_COMMIT` via Vite/env and display in a small footer/About. No backend.
+- Catalog changes: Data additions/edits are PATCH; schema additions MINOR; breaking schema changes MAJOR.
+- See ADR-0006 for details.
+
 ## Tech Choices (see ADR‑0001, ADR‑0003)
 
 - Vue 3 + Vite + TypeScript + Pinia for a simple SPA.

--- a/docs/tasks/llm-gpu-calc/v1/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v1/tasks.md
@@ -168,25 +168,9 @@
     - Gates: N/A.
     - Est: 0.5h
 
-- [ ] 7.0 Versioning & Releases
-  - [ ] 7.1 SemVer source of truth (`package.json`) and tags
-    - Acceptance: `package.json#version` is the authoritative version; README includes a short release flow (`npm version patch|minor|major && git push --follow-tags`); at least one annotated tag `vX.Y.Z` exists for a release.
-    - Gates: Boundaries unaffected; no new runtime deps; docs updated in the same PR.
-    - Traceability: ADR-0006 Versioning and Releases; ARCH-v1 “Versioning (v1)”.
-    - Est: 0.5h
-  - [ ] 7.2 Optional: Build stamping via env (`VITE_APP_VERSION`, `VITE_APP_COMMIT`)
-    - Acceptance: `deploy-pages.yml` sets `VITE_APP_VERSION` (defaults to `npm_package_version`) and `VITE_APP_COMMIT` (`github.sha`); `import.meta.env.VITE_APP_*` values are accessible at runtime.
-    - Gates: Boundaries; no runtime deps; CI diff is minimal.
-    - Traceability: ADR-0006 (Stamping), ARCH-v1 “Versioning (v1)”.
-    - Est: 0.5h
-  - [ ] 7.3 Optional: UI footer/About shows version and short SHA
-    - Acceptance: A small footer or About dialog displays app version (e.g., `1.0.0`) and short commit (e.g., `abcdef1`); feature is non-intrusive and disabled if envs are missing.
-    - Gates: Tests (light UI smoke), Boundaries; no new runtime deps.
-    - Traceability: ADR-0006 (Stamping/UI visibility).
-    - Est: 0.5–1h
-
 ## Notes
 
 - Traceability: See PRD `docs/prd/llm-gpu-calc/v1/prd.md` and ARCH `docs/architecture/ARCH-v1.md`.
+- Versioning & Releases: Managed manually via GitHub UI; see `README.md` (Versioning & Releases) and `docs/adr/ADR-0006-versioning-and-releases.md` for details.
 - Gates: Each sub-task observes Tests, Boundaries, and Dependency rules per `/rules/process-task-list.md`.
 - Estimates: Each sub-task targets 1–4h to complete.

--- a/docs/tasks/llm-gpu-calc/v1/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v1/tasks.md
@@ -168,6 +168,23 @@
     - Gates: N/A.
     - Est: 0.5h
 
+- [ ] 7.0 Versioning & Releases
+  - [ ] 7.1 SemVer source of truth (`package.json`) and tags
+    - Acceptance: `package.json#version` is the authoritative version; README includes a short release flow (`npm version patch|minor|major && git push --follow-tags`); at least one annotated tag `vX.Y.Z` exists for a release.
+    - Gates: Boundaries unaffected; no new runtime deps; docs updated in the same PR.
+    - Traceability: ADR-0006 Versioning and Releases; ARCH-v1 “Versioning (v1)”.
+    - Est: 0.5h
+  - [ ] 7.2 Optional: Build stamping via env (`VITE_APP_VERSION`, `VITE_APP_COMMIT`)
+    - Acceptance: `deploy-pages.yml` sets `VITE_APP_VERSION` (defaults to `npm_package_version`) and `VITE_APP_COMMIT` (`github.sha`); `import.meta.env.VITE_APP_*` values are accessible at runtime.
+    - Gates: Boundaries; no runtime deps; CI diff is minimal.
+    - Traceability: ADR-0006 (Stamping), ARCH-v1 “Versioning (v1)”.
+    - Est: 0.5h
+  - [ ] 7.3 Optional: UI footer/About shows version and short SHA
+    - Acceptance: A small footer or About dialog displays app version (e.g., `1.0.0`) and short commit (e.g., `abcdef1`); feature is non-intrusive and disabled if envs are missing.
+    - Gates: Tests (light UI smoke), Boundaries; no new runtime deps.
+    - Traceability: ADR-0006 (Stamping/UI visibility).
+    - Est: 0.5–1h
+
 ## Notes
 
 - Traceability: See PRD `docs/prd/llm-gpu-calc/v1/prd.md` and ARCH `docs/architecture/ARCH-v1.md`.


### PR DESCRIPTION
This pull request introduces a clear and minimal versioning and release policy for the project, centered on Semantic Versioning and lightweight GitHub-based workflows. The changes document and formalize how versions, releases, and deployments should be managed, with practical instructions for both manual (GitHub UI) and CLI-based flows. The new policy is described in detail in a new ADR and summarized in the main documentation, ensuring consistency and traceability for future releases.

**Versioning & Release Policy Documentation:**

* Added `docs/adr/ADR-0006-versioning-and-releases.md` to formalize the versioning and release process, specifying SemVer usage, tagging, deployment, branching, and optional build stamping.
* Updated `README.md` with a concise "Versioning & Releases (v1)" section, summarizing the policy and providing step-by-step GitHub UI and CLI instructions.
* Expanded `docs/architecture/ARCH-v1.md` with a new section detailing versioning, branching, tagging, deployment, and catalog change classification, referencing the new ADR for further details.
* Added a note in `docs/tasks/llm-gpu-calc/v1/tasks.md` pointing to the new versioning and release documentation for traceability.