### PR TITLE
Tasks 1.0 & 2.0 - Pinia store viewprefs & VizCanvas + Waffle

### DIFF
--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -41,7 +41,7 @@ Repo assessment (concise)
     - Gates: Tests (smoke), Boundaries.
     - Traceability: PRD Module Plan; ARCH‑v3 Key Contracts.
     - Est: 1h
-  - [ ] 1.3 `viewPrefs` in store + sync plugin (URL/localStorage)
+  - [x] 1.3 `viewPrefs` in store + sync plugin (URL/localStorage)
     - Acceptance: Sort/filter/density in store; persists across reloads; shareable via URL.
     - Gates: Tests (persist/restore), no direct component access to URL/localStorage.
     - Traceability: PRD Persistence; ARCH‑v3 Implementation Notes.

--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -58,7 +58,7 @@ Repo assessment (concise)
     - Gates: Visual check; A11y labels present.
     - Traceability: PRD Acceptance (Waffle Tiles).
     - Est: 2h
-  - [ ] 2.3 Sticky controls row (sort/filter chips, legend) bound to `viewPrefs`
+  - [x] 2.3 Sticky controls row (sort/filter chips, legend) bound to `viewPrefs`
     - Acceptance: Controls update store; legend uses tokens; sticky in Viz only.
     - Gates: Boundaries; Tests (store updates reflect in view).
     - Traceability: PRD Viz Controls; ARCH‑v3 Data Flow.

--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -30,7 +30,7 @@ Repo assessment (concise)
     - Traceability: PRD Dependency Policy; ADR‑0004; ADR‑0008/0009.
     - Est: 0.5h
 
-- [ ] 1.0 Pinia store + viewPrefs
+- [x] 1.0 Pinia store + viewPrefs
   - [x] 1.1 Consolidate app state into `useAppStore()`; wrap controller fns as actions
     - Acceptance: Store owns GPUs, models, deployments, prefs; actions: init, setUnit, loadUnitPreference, setGpuCount, incrementGpu, add/remove deployment, applySuggested…
     - Gates: Boundaries; Tests (basic store unit tests if feasible).

--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -31,7 +31,7 @@ Repo assessment (concise)
     - Est: 0.5h
 
 - [ ] 1.0 Pinia store + viewPrefs
-  - [ ] 1.1 Consolidate app state into `useAppStore()`; wrap controller fns as actions
+  - [x] 1.1 Consolidate app state into `useAppStore()`; wrap controller fns as actions
     - Acceptance: Store owns GPUs, models, deployments, prefs; actions: init, setUnit, loadUnitPreference, setGpuCount, incrementGpu, add/remove deployment, applySuggested…
     - Gates: Boundaries; Tests (basic store unit tests if feasible).
     - Traceability: PRD Reference Architecture; ARCH‑v3 Key Contracts.

--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -48,12 +48,12 @@ Repo assessment (concise)
     - Est: 1–2h
 
 - [ ] 2.0 VizCanvas + Waffle visualization
-  - [ ] 2.1 Bytes→cells mapping with largest‑remainder rounding
+  - [x] 2.1 Bytes→cells mapping with largest‑remainder rounding
     - Acceptance: Used+Reserve+Free cells == N×N across representative inputs; stable under small changes.
     - Gates: Tests (mapping totals); Boundaries.
     - Traceability: PRD Visualization; ARCH‑v3 Risks & Mitigations.
     - Est: 2h
-  - [ ] 2.2 Render tiles grid (10×10 default; 20×20 compact)
+  - [x] 2.2 Render tiles grid (10×10 default; 20×20 compact)
     - Acceptance: Responsive auto‑fill grid; headers (name/capacity/status); footers with Used/Reserve/Free.
     - Gates: Visual check; A11y labels present.
     - Traceability: PRD Acceptance (Waffle Tiles).

--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -36,7 +36,7 @@ Repo assessment (concise)
     - Gates: Boundaries; Tests (basic store unit tests if feasible).
     - Traceability: PRD Reference Architecture; ARCH‑v3 Key Contracts.
     - Est: 2h
-  - [ ] 1.2 Getters for derived data (resultsStub, perGpuBars, fitStatus, kpis)
+  - [x] 1.2 Getters for derived data (resultsStub, perGpuBars, fitStatus, kpis)
     - Acceptance: Getters delegate to controller; deterministic given state; no UI logic in store.
     - Gates: Tests (smoke), Boundaries.
     - Traceability: PRD Module Plan; ARCH‑v3 Key Contracts.

--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -63,7 +63,7 @@ Repo assessment (concise)
     - Gates: Boundaries; Tests (store updates reflect in view).
     - Traceability: PRD Viz Controls; ARCH‑v3 Data Flow.
     - Est: 1–2h
-  - [ ] 2.4 Performance guard: auto‑downgrade density when GPU count high
+  - [x] 2.4 Performance guard: auto‑downgrade density when GPU count high
     - Acceptance: Threshold implemented (e.g., ≥32 GPUs → 10×10); smooth hover/scroll.
     - Gates: Manual perf check.
     - Traceability: PRD Performance; ARCH‑v3 Non‑Functionals.

--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -47,7 +47,7 @@ Repo assessment (concise)
     - Traceability: PRD Persistence; ARCH‑v3 Implementation Notes.
     - Est: 1–2h
 
-- [ ] 2.0 VizCanvas + Waffle visualization
+- [x] 2.0 VizCanvas + Waffle visualization
   - [x] 2.1 Bytes→cells mapping with largest‑remainder rounding
     - Acceptance: Used+Reserve+Free cells == N×N across representative inputs; stable under small changes.
     - Gates: Tests (mapping totals); Boundaries.

--- a/src/app/controller.ts
+++ b/src/app/controller.ts
@@ -260,7 +260,7 @@ export function mapBytesToWaffleCells(
   }
 
   let remaining = totalCells - assigned;
-  if (remaining <= 0) {
+  if (remaining < 0) {
     // Guard against any floating point drift that made us overshoot.
     while (remaining < 0) {
       // Remove from the smallest remainder / reverse tie-break order.

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,3 +1,3 @@
 export * from './state';
 export * from './controller';
-
+export * from './store';

--- a/src/app/store.getters.test.ts
+++ b/src/app/store.getters.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useAppStore } from './store'
 import type { AppState } from './state'
-import { computeResultsStub, buildPerGpuBars, buildPerGpuFitStatus } from './controller'
+import { computeResultsStub, buildPerGpuBars, buildPerGpuFitStatus, buildPerGpuWaffleCells } from './controller'
 
 function asAppState(s: unknown): AppState {
   return s as AppState
@@ -44,11 +44,19 @@ describe('useAppStore getters delegate to controller', () => {
     const f2 = buildPerGpuFitStatus(state)
     expect(f1).toEqual(f2)
 
+    const w1 = store.waffleCells
+    const w2 = buildPerGpuWaffleCells(state, 10)
+    expect(w1).toEqual(w2)
+
     // Determinism: unrelated viewPref changes do not affect outputs
     const snapshot = JSON.stringify({ r1, b1, f1 })
     store.setDensity('20x20')
+    const stateAfter = asAppState(store)
+    const w3 = store.waffleCells
+    const w4 = buildPerGpuWaffleCells(stateAfter, 20)
+    expect(w3).toEqual(w4)
+
     const snapshot2 = JSON.stringify({ r1: store.resultsStub, b1: store.perGpuBars, f1: store.fitStatus })
     expect(snapshot2).toEqual(snapshot)
   })
 })
-

--- a/src/app/store.getters.test.ts
+++ b/src/app/store.getters.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAppStore } from './store'
+import type { AppState } from './state'
+import { computeResultsStub, buildPerGpuBars, buildPerGpuFitStatus } from './controller'
+
+function asAppState(s: unknown): AppState {
+  return s as AppState
+}
+
+describe('useAppStore getters delegate to controller', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('resultsStub / perGpuBars / fitStatus match controller outputs and are deterministic', () => {
+    const store = useAppStore()
+    store.init()
+
+    // Ensure at least one GPU and one deployment assigned to generate non-trivial outputs
+    const typeId = store.gpuCatalog[0]?.id
+    expect(typeId).toBeTruthy()
+    if (!typeId) return
+    store.setGpuCount(typeId, 1)
+    store.addDeployment()
+    const gpuId = store.gpus[0]?.id
+    expect(gpuId).toBeTruthy()
+    if (!gpuId) return
+    const dep = store.deployments[0]
+    dep.assignedGpuIds = [gpuId]
+    dep.modelId = store.models[0]?.id ?? ''
+
+    const state = asAppState(store)
+
+    const r1 = store.resultsStub
+    const r2 = computeResultsStub(state)
+    expect(r1).toEqual(r2)
+
+    const b1 = store.perGpuBars
+    const b2 = buildPerGpuBars(state)
+    expect(b1).toEqual(b2)
+
+    const f1 = store.fitStatus
+    const f2 = buildPerGpuFitStatus(state)
+    expect(f1).toEqual(f2)
+
+    // Determinism: unrelated viewPref changes do not affect outputs
+    const snapshot = JSON.stringify({ r1, b1, f1 })
+    store.setDensity('20x20')
+    const snapshot2 = JSON.stringify({ r1: store.resultsStub, b1: store.perGpuBars, f1: store.fitStatus })
+    expect(snapshot2).toEqual(snapshot)
+  })
+})
+

--- a/src/app/store.getters.test.ts
+++ b/src/app/store.getters.test.ts
@@ -59,4 +59,20 @@ describe('useAppStore getters delegate to controller', () => {
     const snapshot2 = JSON.stringify({ r1: store.resultsStub, b1: store.perGpuBars, f1: store.fitStatus })
     expect(snapshot2).toEqual(snapshot)
   })
+
+  it('auto-downgrades density to 10x10 when GPU count is high', () => {
+    const store = useAppStore()
+    store.init()
+    const typeId = store.gpuCatalog[0]?.id
+    expect(typeId).toBeTruthy()
+    if (!typeId) return
+
+    store.setDensity('20x20')
+    store.setGpuCount(typeId, 40)
+
+    expect(store.viewPrefs.density).toBe('20x20')
+    expect(store.effectiveDensity).toBe('10x10')
+    const cells = store.waffleCells
+    expect(cells.every((entry: any) => entry.gridSize === 10)).toBe(true)
+  })
 })

--- a/src/app/store.test.ts
+++ b/src/app/store.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAppStore } from './store'
+
+describe('useAppStore (basic)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('initializes catalogs on init()', () => {
+    const store = useAppStore()
+    expect(store.gpuCatalog.length).toBe(0)
+    expect(store.models.length).toBe(0)
+    store.init()
+    expect(store.gpuCatalog.length).toBeGreaterThan(0)
+    expect(store.models.length).toBeGreaterThan(0)
+  })
+
+  it('sets and increments GPU counts and rebuilds selected GPUs', () => {
+    const store = useAppStore()
+    store.init()
+    const typeId = store.gpuCatalog[0]?.id
+    expect(typeId).toBeTruthy()
+    if (!typeId) return
+    store.setGpuCount(typeId, 2)
+    expect(store.gpuCounts[typeId]).toBe(2)
+    expect(store.gpus.filter(g => g.id.startsWith(typeId)).length).toBe(2)
+    store.incrementGpu(typeId, 1)
+    expect(store.gpuCounts[typeId]).toBe(3)
+    expect(store.gpus.filter(g => g.id.startsWith(typeId)).length).toBe(3)
+  })
+
+  it('adds and removes deployments', () => {
+    const store = useAppStore()
+    store.init()
+    const before = store.deployments.length
+    store.addDeployment()
+    expect(store.deployments.length).toBe(before + 1)
+    const id = store.deployments[store.deployments.length - 1].id
+    store.removeDeployment(id)
+    expect(store.deployments.some(d => d.id === id)).toBe(false)
+  })
+})
+

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -12,6 +12,7 @@ import {
   computeResultsStub,
   buildPerGpuBars,
   buildPerGpuFitStatus,
+  buildPerGpuWaffleCells,
   applySuggestedMaxModelLen as applySuggestedMaxModelLenController,
   applySuggestedMaxNumSeqs as applySuggestedMaxNumSeqsController,
 } from './controller'
@@ -52,6 +53,11 @@ export const useAppStore = defineStore('app', {
     },
     fitStatus(state) {
       return buildPerGpuFitStatus(state as unknown as AppState)
+    },
+    waffleCells(state) {
+      const density = state.viewPrefs?.density ?? '10x10'
+      const gridSize = density === '20x20' ? 20 : 10
+      return buildPerGpuWaffleCells(state as unknown as AppState, gridSize)
     },
     kpis(state) {
       const results = computeResultsStub(state as unknown as AppState)

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -83,7 +83,7 @@ export const useAppStore = defineStore('app', {
         totalUsed += Math.max(0, r.usedBytes)
         totalReserve += Math.max(0, r.impliedReserveFrac * r.capacityBytes)
         const f = fit.get(r.gpuId)
-        if (f && f.ok === false) warnings += 1
+        if (f && !f.ok) warnings += 1
       }
       return {
         gpus: results.length,

--- a/src/app/viewPrefs.test.ts
+++ b/src/app/viewPrefs.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  defaultViewPrefs,
+  parseFromURL,
+  applyToURL,
+  persistToLocalStorage,
+  loadFromLocalStorage,
+  type ViewPrefsShape,
+} from './viewPrefs'
+
+describe('viewPrefs utilities', () => {
+  beforeEach(() => {
+    // simple in-memory localStorage mock
+    const store = new Map<string, string>()
+    ;(globalThis as any).localStorage = {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => { store.set(k, v) },
+      removeItem: (k: string) => { store.delete(k) },
+      clear: () => { store.clear() },
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() { return store.size },
+    }
+  })
+
+  it('parses from URL and applies to URL with only non-defaults', () => {
+    const parsed = parseFromURL('?density=20&sort=status_used&status=warn&vendor=NVIDIA&q=h100')
+    expect(parsed.density).toBe('20x20')
+    expect(parsed.sort).toBe('status_used')
+    expect(parsed.statusFilter).toBe('warn')
+    expect(parsed.vendorFilter).toBe('NVIDIA')
+    expect(parsed.search).toBe('h100')
+
+    const prefs: ViewPrefsShape = {
+      ...defaultViewPrefs,
+      density: '20x20', // non-default
+      statusFilter: 'warn', // non-default
+    }
+    const q = applyToURL('', prefs)
+    // sort is default, vendor/search default -> not present
+    expect(q.includes('density=20x20')).toBe(true)
+    expect(q.includes('status=warn')).toBe(true)
+    expect(q.includes('sort=')).toBe(false)
+    expect(q.includes('vendor=')).toBe(false)
+    expect(q.includes('q=')).toBe(false)
+  })
+
+  it('persists to and loads from localStorage', () => {
+    const prefs: ViewPrefsShape = {
+      ...defaultViewPrefs,
+      density: '20x20',
+      sort: 'status_used',
+      statusFilter: 'over',
+      vendorFilter: 'NVIDIA',
+      search: 'A100',
+    }
+    persistToLocalStorage(prefs)
+    const loaded = loadFromLocalStorage()
+    expect(loaded.density).toBe('20x20')
+    expect(loaded.statusFilter).toBe('over')
+    expect(loaded.vendorFilter).toBe('NVIDIA')
+    expect(loaded.search).toBe('A100')
+  })
+})
+

--- a/src/app/viewPrefs.ts
+++ b/src/app/viewPrefs.ts
@@ -1,0 +1,94 @@
+// Utilities to parse and persist view preferences via URL and localStorage
+
+export type Density = '10x10' | '20x20'
+
+export interface ViewPrefsShape {
+  density: Density
+  sort: string
+  statusFilter: string // 'all' | 'ok' | 'warn' | 'over'
+  vendorFilter: string // e.g., 'NVIDIA' | 'AMD' | '' (all)
+  search: string
+}
+
+const LS_KEY = 'viewPrefs.v3'
+
+export const defaultViewPrefs: ViewPrefsShape = {
+  density: '10x10',
+  sort: 'status_used',
+  statusFilter: 'all',
+  vendorFilter: '',
+  search: '',
+}
+
+export function normalizeDensity(input: string | null | undefined): Density | undefined {
+  if (!input) return undefined
+  const v = input.toLowerCase()
+  if (v === '10' || v === '10x10') return '10x10'
+  if (v === '20' || v === '20x20') return '20x20'
+  return undefined
+}
+
+export function parseFromURL(search: string): Partial<ViewPrefsShape> {
+  try {
+    const qp = new URLSearchParams(search)
+    const density = normalizeDensity(qp.get('density') || undefined)
+    const sort = qp.get('sort') || undefined
+    const status = qp.get('status') || undefined
+    const vendor = qp.get('vendor') || undefined
+    const q = qp.get('q') || undefined
+    const out: Partial<ViewPrefsShape> = {}
+    if (density) out.density = density
+    if (sort) out.sort = sort
+    if (status) out.statusFilter = status
+    if (vendor !== undefined) out.vendorFilter = vendor
+    if (q !== undefined) out.search = q
+    return out
+  } catch {
+    return {}
+  }
+}
+
+export function loadFromLocalStorage(): Partial<ViewPrefsShape> {
+  try {
+    const raw = localStorage.getItem(LS_KEY)
+    if (!raw) return {}
+    const obj = JSON.parse(raw)
+    const out: Partial<ViewPrefsShape> = {}
+    if (obj && typeof obj === 'object') {
+      if (obj.density) out.density = normalizeDensity(String(obj.density)) || defaultViewPrefs.density
+      if (typeof obj.sort === 'string') out.sort = obj.sort
+      if (typeof obj.statusFilter === 'string') out.statusFilter = obj.statusFilter
+      if (typeof obj.vendorFilter === 'string') out.vendorFilter = obj.vendorFilter
+      if (typeof obj.search === 'string') out.search = obj.search
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+export function persistToLocalStorage(prefs: ViewPrefsShape): void {
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify(prefs))
+  } catch {}
+}
+
+export function applyToURL(currentSearch: string, prefs: ViewPrefsShape): string {
+  try {
+    const qp = new URLSearchParams(currentSearch)
+    // only include non-defaults to keep URLs clean
+    const setOrDelete = (k: string, value: string, defaultValue: string) => {
+      if (value && value !== defaultValue) qp.set(k, value)
+      else qp.delete(k)
+    }
+    setOrDelete('density', prefs.density, defaultViewPrefs.density)
+    setOrDelete('sort', prefs.sort, defaultViewPrefs.sort)
+    setOrDelete('status', prefs.statusFilter, defaultViewPrefs.statusFilter)
+    setOrDelete('vendor', prefs.vendorFilter, defaultViewPrefs.vendorFilter)
+    setOrDelete('q', prefs.search, defaultViewPrefs.search)
+    return qp.toString()
+  } catch {
+    return currentSearch.replace(/^\?/, '')
+  }
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,20 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import { DashboardShell } from '@ui'
 import { isV3ShellEnabled } from './flags'
+import { useAppStore } from '@app'
 import './styles/index.css'
 
 const Root = isV3ShellEnabled() ? DashboardShell : App
+const pinia = createPinia()
 const app = createApp(Root)
-app.use(createPinia())
+app.use(pinia)
+
+// Initialize store when v3 shell is enabled (no UI code touches URL/LS directly)
+if (isV3ShellEnabled()) {
+  const store = useAppStore()
+  store.init()
+  store.loadUnitPreference()
+  store.startViewPrefsSync()
+}
+
 app.mount('#app-root')

--- a/src/ui/viz/PerGpuWaffle.vue
+++ b/src/ui/viz/PerGpuWaffle.vue
@@ -1,19 +1,234 @@
 <template>
-  <div class="grid gap-4" style="grid-template-columns: repeat(auto-fill, minmax(260px, 1fr))">
-    <!-- Stub tiles: real mapping and data binding arrive in later tasks -->
-    <div class="border rounded-md p-3 text-xs text-slate-600 dark:text-slate-300" v-for="n in 3" :key="n">
-      <div class="font-medium mb-2">GPU #{{ n }} — Waffle (stub)</div>
-      <div class="grid grid-cols-10 gap-[1px]">
-        <div v-for="i in 100" :key="i" class="w-3 h-3 bg-slate-200 dark:bg-slate-700"></div>
+  <div class="viz-waffle-grid">
+    <article v-for="tile in tiles" :key="tile.gpuId" class="tile">
+      <header class="tile__header">
+        <div class="tile__title">
+          <span class="tile__name">{{ tile.gpuName }}</span>
+          <span class="tile__capacity">{{ tile.capacityLabel }}</span>
+        </div>
+        <span class="tile__status" :class="tile.statusClass" :title="tile.statusTitle">
+          {{ tile.statusText }}
+        </span>
+      </header>
+
+      <div
+        class="tile__grid"
+        role="img"
+        :aria-label="tile.ariaLabel"
+        :style="{ gridTemplateColumns: `repeat(${tile.gridSize}, minmax(0, 1fr))` }"
+      >
+        <div
+          v-for="(cell, idx) in tile.cells"
+          :key="idx"
+          class="tile__cell"
+          :style="cellStyle(cell, tile.cellSize)"
+          aria-hidden="true"
+        />
       </div>
-      <div class="mt-2 text-[11px] text-slate-500">Used 0% • Reserve 0% • Free 100%</div>
-    </div>
+
+      <footer class="tile__footer">
+        Used {{ tile.usedPercent }}% • Reserve {{ tile.reservePercent }}% • Free {{ tile.freePercent }}%
+      </footer>
+    </article>
+
+    <p v-if="tiles.length === 0" class="tile__empty">Select GPUs to populate the waffle visualization.</p>
   </div>
 </template>
 
 <script setup lang="ts">
-// Public API target (per PRD):
-// props could accept precomputed tiles; for now keep as stub
-// defineProps<{ tiles?: Array<unknown> }>()
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useAppStore } from '@app/store'
+import { gpuCapacityLabel, type WaffleCategory } from '@app/controller'
+import type { Gpu } from '@shared/types'
+
+const store = useAppStore()
+const { waffleCells, fitStatus } = storeToRefs(store)
+
+type TileStatus = {
+  text: 'Over' | 'Warning' | 'OK'
+  class: string
+  title: string
+}
+
+function resolveStatus(gpuId: string): TileStatus {
+  const status = fitStatus.value.find((s) => s.gpuId === gpuId)
+  if (!status) {
+    return { text: 'OK', class: 'is-ok', title: 'No status available' }
+  }
+  const reason = status.reason ?? ''
+  if (!status.ok) {
+    return { text: 'Over', class: 'is-over', title: reason || 'Over capacity or no headroom' }
+  }
+  if (reason.includes('High utilization')) {
+    return { text: 'Warning', class: 'is-warn', title: reason }
+  }
+  return { text: 'OK', class: 'is-ok', title: reason || 'Within capacity' }
+}
+
+const order: WaffleCategory[] = ['weights', 'kv', 'reserve', 'free']
+
+function expandCells(counts: Record<WaffleCategory, number>, total: number): WaffleCategory[] {
+  const slots: WaffleCategory[] = []
+  for (const kind of order) {
+    const n = counts[kind] || 0
+    for (let i = 0; i < n; i++) slots.push(kind)
+  }
+  if (slots.length > total) return slots.slice(0, total)
+  while (slots.length < total) slots.push('free')
+  return slots
+}
+
+function percentOf(value: number, capacity: number): string {
+  if (!capacity) return '0'
+  const pct = (value / capacity) * 100
+  return pct >= 99.5 ? '100' : pct <= 0.5 ? '0' : pct.toFixed(0)
+}
+
+const tiles = computed(() => {
+  return (waffleCells.value ?? []).map((entry) => {
+    const status = resolveStatus(entry.gpuId)
+    const totalCells = entry.totalCells || entry.gridSize ** 2
+    const cells = expandCells(entry.cells, totalCells)
+    const usedBytes = entry.weightsBytes + entry.kvBytes
+    const capacity = entry.capacityBytes || 1
+    const usedPercent = percentOf(usedBytes, capacity)
+    const reservePercent = percentOf(entry.reserveBytes, capacity)
+    const freePercent = percentOf(entry.freeBytes, capacity)
+    const densityLabel = entry.gridSize === 20 ? '20×20 compact grid' : '10×10 default grid'
+    const ariaLabel = `${entry.gpuName} waffle (${densityLabel}). Used ${usedPercent} percent (weights ${percentOf(entry.weightsBytes, capacity)}%, KV ${percentOf(entry.kvBytes, capacity)}%), reserve ${reservePercent} percent, free ${freePercent} percent.`
+    const cellSize = entry.gridSize >= 20 ? '0.55rem' : '0.7rem'
+    const gpuMeta: Gpu = { id: entry.gpuId, name: entry.gpuName, vramBytes: entry.capacityBytes }
+
+    return {
+      gpuId: entry.gpuId,
+      gpuName: entry.gpuName,
+      capacityLabel: gpuCapacityLabel(gpuMeta),
+      statusText: status.text,
+      statusClass: status.class,
+      statusTitle: status.title,
+      gridSize: entry.gridSize,
+      cells,
+      usedPercent,
+      reservePercent,
+      freePercent,
+      ariaLabel,
+      cellSize,
+    }
+  })
+})
+
+function cellStyle(kind: WaffleCategory, size: string) {
+  const color =
+    kind === 'weights'
+      ? 'var(--color-weights)'
+      : kind === 'kv'
+      ? 'var(--color-kv)'
+      : kind === 'reserve'
+      ? 'var(--color-reserve)'
+      : 'var(--color-unallocated)'
+  return {
+    width: size,
+    height: size,
+    backgroundColor: color,
+  }
+}
 </script>
 
+<style scoped>
+.viz-waffle-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.tile {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: var(--color-surface, #f5f5f7);
+  color: var(--color-text, #1d1d1f);
+}
+
+.tile__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 0.5rem;
+}
+
+.tile__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.tile__name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.tile__capacity {
+  font-size: 0.75rem;
+  color: var(--color-muted, #6e6e73);
+}
+
+.tile__status {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.tile__status.is-ok {
+  background: rgba(48, 209, 88, 0.12);
+  color: var(--color-success, #34c759);
+}
+
+.tile__status.is-warn {
+  background: rgba(255, 159, 10, 0.12);
+  color: var(--color-warning, #ff9f0a);
+}
+
+.tile__status.is-over {
+  background: rgba(255, 59, 48, 0.15);
+  color: var(--color-danger, #ff3b30);
+}
+
+.tile__grid {
+  display: grid;
+  gap: 1px;
+  align-self: stretch;
+}
+
+.tile__cell {
+  border-radius: 1px;
+}
+
+.tile__footer {
+  margin-top: auto;
+  font-size: 0.7rem;
+  color: var(--color-muted, #6e6e73);
+}
+
+.tile__empty {
+  grid-column: 1 / -1;
+  padding: 1.5rem;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: var(--radius-md);
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--color-muted, #6e6e73);
+}
+
+@media (max-width: 640px) {
+  .viz-waffle-grid {
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  }
+}
+</style>

--- a/src/ui/viz/VizControls.vue
+++ b/src/ui/viz/VizControls.vue
@@ -53,8 +53,8 @@
           :key="option.value"
           type="button"
           class="chip"
-          :class="{ 'is-active': viewPrefs.density === option.value }"
-          :aria-pressed="viewPrefs.density === option.value"
+          :class="{ 'is-active': effectiveDensity === option.value }"
+          :aria-pressed="effectiveDensity === option.value"
           @click="setDensity(option.value)"
         >
           {{ option.label }}
@@ -69,11 +69,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
-import { useAppStore } from '@app/store'
+import { useAppStore, type Density } from '@app/store'
 import Legend from '@ui/Legend.vue'
 
 const store = useAppStore()
-const { viewPrefs, gpuCatalog } = storeToRefs(store)
+const { viewPrefs, gpuCatalog, effectiveDensity } = storeToRefs(store)
 
 const sortOptions = [
   { value: 'status_used', label: 'Status → Used%' },
@@ -88,7 +88,7 @@ const statusOptions = [
   { value: 'over', label: 'Over' },
 ]
 
-const densityOptions = [
+const densityOptions: ReadonlyArray<{ value: Density; label: string }> = [
   { value: '10x10', label: 'Comfort' },
   { value: '20x20', label: 'Compact' },
 ]
@@ -119,7 +119,7 @@ function setVendor(value: string) {
   store.setVendorFilter(value)
 }
 
-function setDensity(value: '10x10' | '20x20') {
+function setDensity(value: Density) {
   if (viewPrefs.value.density === value) return
   store.setDensity(value)
 }
@@ -211,4 +211,3 @@ function setDensity(value: '10x10' | '20x20') {
   }
 }
 </style>
-

--- a/src/ui/viz/VizControls.vue
+++ b/src/ui/viz/VizControls.vue
@@ -1,11 +1,214 @@
 <template>
-  <div class="px-4 py-2 flex items-center gap-2">
-    <span class="text-xs text-slate-500">Viz controls (stub)</span>
-    <!-- Chips for Sort, Filter, Density will be implemented later -->
+  <div class="viz-controls" role="region" aria-label="Visualization controls">
+    <div class="viz-controls__primary">
+      <div class="chip-group" role="group" aria-label="Sort GPUs">
+        <span class="chip-group__label">Sort</span>
+        <button
+          v-for="option in sortOptions"
+          :key="option.value"
+          type="button"
+          class="chip"
+          :class="{ 'is-active': viewPrefs.sort === option.value }"
+          :aria-pressed="viewPrefs.sort === option.value"
+          @click="setSort(option.value)"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+
+      <div class="chip-group" role="group" aria-label="Filter by status">
+        <span class="chip-group__label">Status</span>
+        <button
+          v-for="option in statusOptions"
+          :key="option.value"
+          type="button"
+          class="chip"
+          :class="{ 'is-active': viewPrefs.statusFilter === option.value }"
+          :aria-pressed="viewPrefs.statusFilter === option.value"
+          @click="setStatusFilter(option.value)"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+
+      <div class="chip-group" role="group" aria-label="Filter by vendor">
+        <span class="chip-group__label">Vendor</span>
+        <button
+          v-for="option in vendorOptions"
+          :key="option.value"
+          type="button"
+          class="chip"
+          :class="{ 'is-active': viewPrefs.vendorFilter === option.value }"
+          :aria-pressed="viewPrefs.vendorFilter === option.value"
+          @click="setVendor(option.value)"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+
+      <div class="chip-group" role="group" aria-label="Set grid density">
+        <span class="chip-group__label">Density</span>
+        <button
+          v-for="option in densityOptions"
+          :key="option.value"
+          type="button"
+          class="chip"
+          :class="{ 'is-active': viewPrefs.density === option.value }"
+          :aria-pressed="viewPrefs.density === option.value"
+          @click="setDensity(option.value)"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+    </div>
+
+    <Legend class="viz-controls__legend" />
   </div>
 </template>
 
 <script setup lang="ts">
-// Stub only
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useAppStore } from '@app/store'
+import Legend from '@ui/Legend.vue'
+
+const store = useAppStore()
+const { viewPrefs, gpuCatalog } = storeToRefs(store)
+
+const sortOptions = [
+  { value: 'status_used', label: 'Status → Used%' },
+  { value: 'used_desc', label: 'Used% ↓' },
+  { value: 'name_asc', label: 'Name A→Z' },
+]
+
+const statusOptions = [
+  { value: 'all', label: 'All' },
+  { value: 'ok', label: 'OK' },
+  { value: 'warn', label: 'Warnings' },
+  { value: 'over', label: 'Over' },
+]
+
+const densityOptions = [
+  { value: '10x10', label: 'Comfort' },
+  { value: '20x20', label: 'Compact' },
+]
+
+const vendorOptions = computed(() => {
+  const vendors = new Set<string>()
+  for (const gpu of gpuCatalog.value) {
+    if (gpu.vendor) vendors.add(gpu.vendor)
+  }
+  return [
+    { value: '', label: 'All' },
+    ...Array.from(vendors).sort().map((v) => ({ value: v, label: v })),
+  ]
+})
+
+function setSort(value: string) {
+  if (viewPrefs.value.sort === value) return
+  store.setSort(value)
+}
+
+function setStatusFilter(value: string) {
+  if (viewPrefs.value.statusFilter === value) return
+  store.setStatusFilter(value)
+}
+
+function setVendor(value: string) {
+  if (viewPrefs.value.vendorFilter === value) return
+  store.setVendorFilter(value)
+}
+
+function setDensity(value: '10x10' | '20x20') {
+  if (viewPrefs.value.density === value) return
+  store.setDensity(value)
+}
 </script>
+
+<style scoped>
+.viz-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: 0.75rem 1rem;
+  backdrop-filter: blur(12px);
+  background: color-mix(in srgb, var(--color-surface, #f5f5f7) 90%, transparent);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.viz-controls__primary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.chip-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.chip-group__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-muted, #6e6e73);
+}
+
+.chip {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--color-muted, #6e6e73);
+  background: rgba(255, 255, 255, 0.6);
+  transition: all 0.15s ease;
+}
+
+.chip:hover {
+  border-color: rgba(148, 163, 184, 0.6);
+  color: var(--color-text, #1d1d1f);
+}
+
+.chip:focus-visible {
+  outline: 2px solid var(--color-primary, #0071e3);
+  outline-offset: 2px;
+}
+
+.chip.is-active {
+  border-color: var(--color-primary, #0071e3);
+  color: var(--color-primary, #0071e3);
+  background: rgba(0, 113, 227, 0.08);
+}
+
+.viz-controls__legend {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  min-width: 200px;
+}
+
+@media (max-width: 960px) {
+  .viz-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .viz-controls__legend {
+    justify-content: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chip,
+  .chip:hover {
+    transition: none;
+  }
+}
+</style>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "paths": {
       "@ui": ["src/ui/index.ts"],
       "@ui/*": ["src/ui/*"],
+      "@app": ["src/app/index.ts"],
       "@app/*": ["src/app/*"],
       "@domain/*": ["src/domain/*"],
       "@data/*": ["src/data/*"],


### PR DESCRIPTION
This pull request introduces a new waffle visualization feature for GPU memory usage and significantly upgrades the Pinia store to support richer view preferences and state synchronization. It also adds comprehensive unit tests for both the new visualization logic and the store/viewPrefs functionality. The changes improve state management, visualization accuracy, and user experience for view preference persistence.

**Waffle Visualization and Controller Enhancements:**

- Added `mapBytesToWaffleCells` and `buildPerGpuWaffleCells` to `controller.ts` to map memory usage bytes into a fixed-size grid (waffle chart) using largest-remainder rounding, ensuring stable and accurate visual representation. Includes tie-break logic for deterministic cell allocation and robust handling of edge cases.
- Extended controller unit tests to cover the new waffle mapping logic, including rounding, tie-breaking, and aggregation from controller data.
- Exported new controller helpers in `index.ts` for external use.

**Pinia Store Improvements:**

- Refactored the Pinia store to:
  - Consolidate app state and controller actions.
  - Add viewPrefs for density, sorting, filtering, and search, with corresponding setters and a `startViewPrefsSync` method to persist and synchronize preferences with URL/localStorage. [[1]](diffhunk://#diff-efbc9c2c3c62a72fb9d047216d1c0ed4a8223e51ce11cbcbb30a7a0a6049d042R15-R76) [[2]](diffhunk://#diff-efbc9c2c3c62a72fb9d047216d1c0ed4a8223e51ce11cbcbb30a7a0a6049d042R129-R182)
  - Add an `effectiveDensity` getter that auto-downgrades waffle density for large GPU counts (≥32).
  - Add a `waffleCells` getter that computes per-GPU waffle cell distributions, delegating to the controller.
- Added unit tests for the store, verifying initialization, GPU/deployment actions, and getter correctness/determinism. [[1]](diffhunk://#diff-7746e47b687008e94b0a75a45582eb7e8c3c19bc02c066ec25dd8f2942d6503aR1-R44) [[2]](diffhunk://#diff-6c9e939dd1b309a513a8d181076ecb49589315458f4fa605a1cb7e11c0706794R1-R78)

**View Preferences Utilities:**

- Added a `viewPrefs` utility module with helpers for parsing, persisting, and applying view preferences to/from URL and localStorage.
- Added thorough tests for these utilities, including localStorage mocking and URL query handling.

**Documentation and Task Tracking:**

- Updated `docs/tasks/llm-gpu-calc/v3/tasks.md` to mark the Pinia store, viewPrefs, and waffle visualization tasks as complete, reflecting the implementation in this PR.

**Test Coverage:**

- Added and updated tests for all new features and logic, ensuring correctness and robustness. [[1]](diffhunk://#diff-b123081fd6bcf3094993a6073e5192de2f6b2ff572976f532aaa1c3e5294548aR300-R364) [[2]](diffhunk://#diff-7746e47b687008e94b0a75a45582eb7e8c3c19bc02c066ec25dd8f2942d6503aR1-R44) [[3]](diffhunk://#diff-6c9e939dd1b309a513a8d181076ecb49589315458f4fa605a1cb7e11c0706794R1-R78) [[4]](diffhunk://#diff-c10d215cde40769b165437841a16140592c4ea0a46a63c6d50a6bd4e1cbbc25bR1-R64)

These changes collectively provide a robust, accurate, and user-friendly foundation for GPU memory visualization and preference management in the app.