### PR TITLE
Tasks 4.0 - Insights Drawer

### DIFF
--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -89,7 +89,7 @@ Repo assessment (concise)
     - Traceability: PRD Keyboard Shortcuts.
     - Est: 0.5–1h
 
-- [ ] 4.0 InsightsDrawer (right overlay)
+- [x] 4.0 InsightsDrawer (right overlay)
   - [x] 4.1 Fit status list from `buildPerGpuFitStatus`
     - Notes: Implemented InsightsDrawer overlay with fit status list, reusable badge helper, and insights rows utility + tests.
     - Acceptance: Deterministic display; status badges reflect reasons.

--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -90,7 +90,8 @@ Repo assessment (concise)
     - Est: 0.5–1h
 
 - [ ] 4.0 InsightsDrawer (right overlay)
-  - [ ] 4.1 Fit status list from `buildPerGpuFitStatus`
+  - [x] 4.1 Fit status list from `buildPerGpuFitStatus`
+    - Notes: Implemented InsightsDrawer overlay with fit status list, reusable badge helper, and insights rows utility + tests.
     - Acceptance: Deterministic display; status badges reflect reasons.
     - Gates: Tests (smoke), Boundaries.
     - Traceability: PRD Acceptance (Layout & Navigation), ARCH‑v3 Key Contracts.

--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -102,7 +102,8 @@ Repo assessment (concise)
     - Gates: Tests (apply paths), Boundaries.
     - Traceability: PRD Acceptance (Suggestions via Insights), ARCH‑v3.
     - Est: 1–2h
-  - [ ] 4.3 “Only warnings” chip integrates with `viewPrefs` and opens drawer (`F`)
+  - [x] 4.3 “Only warnings” chip integrates with `viewPrefs` and opens drawer (`F`)
+    - Notes: Added toggle chip + `F` shortcut wiring to set `viewPrefs.statusFilter='warn'`, open/close Insights, and updated shortcut resolver/tests.
     - Acceptance: Clicking KPI Warnings sets filter + opens drawer; keyboard `F` toggles.
     - Gates: Accessibility; Tests (interaction).
     - Traceability: PRD KPI Deep‑links; Viz Controls.

--- a/docs/tasks/llm-gpu-calc/v3/tasks.md
+++ b/docs/tasks/llm-gpu-calc/v3/tasks.md
@@ -96,7 +96,8 @@ Repo assessment (concise)
     - Gates: Tests (smoke), Boundaries.
     - Traceability: PRD Acceptance (Layout & Navigation), ARCH‑v3 Key Contracts.
     - Est: 1–2h
-  - [ ] 4.2 Suggestions with Apply actions
+  - [x] 4.2 Suggestions with Apply actions
+    - Notes: Added suggestions helper + tests, surfaced apply buttons in InsightsDrawer, wired to store actions so deployments update immediately.
     - Acceptance: Apply updates state via store actions; re-renders Viz.
     - Gates: Tests (apply paths), Boundaries.
     - Traceability: PRD Acceptance (Suggestions via Insights), ARCH‑v3.

--- a/src/ui/dock/InsightsDrawer.vue
+++ b/src/ui/dock/InsightsDrawer.vue
@@ -27,11 +27,21 @@
             <h2 id="insights-title">Fit Status Overview</h2>
             <p class="insights__subtitle">Monitor capacity pressure across selected GPUs.</p>
           </div>
-          <button type="button" class="insights__close" aria-label="Close Insights" @click="onClose">
-            <svg aria-hidden="true" viewBox="0 0 16 16" class="insights__close-icon">
-              <path d="M3.2 3.2L12.8 12.8M12.8 3.2L3.2 12.8" />
-            </svg>
-          </button>
+          <div class="insights__header-actions">
+            <button
+              type="button"
+              class="insights__chip"
+              :class="{ 'is-active': onlyWarningsActive }"
+              @click="toggleOnlyWarnings"
+            >
+              Only warnings
+            </button>
+            <button type="button" class="insights__close" aria-label="Close Insights" @click="onClose">
+              <svg aria-hidden="true" viewBox="0 0 16 16" class="insights__close-icon">
+                <path d="M3.2 3.2L12.8 12.8M12.8 3.2L3.2 12.8" />
+              </svg>
+            </button>
+          </div>
         </header>
 
         <section class="insights__content" aria-live="polite" aria-busy="false">
@@ -117,7 +127,7 @@ const emit = defineEmits<{ (e: 'close'): void }>()
 
 const rootRef = ref<HTMLElement | null>(null)
 const store = useAppStore()
-const { fitStatus, gpus, gpuCatalog, unit, deployments } = storeToRefs(store)
+const { fitStatus, gpus, gpuCatalog, unit, deployments, viewPrefs } = storeToRefs(store)
 
 const rows = computed(() =>
   buildInsightRows({
@@ -133,6 +143,8 @@ const suggestions = computed(() =>
     state: { ...store.$state, deployments: deployments.value } as AppState,
   })
 )
+
+const onlyWarningsActive = computed(() => viewPrefs.value.statusFilter === 'warn')
 
 watch(
   () => props.open,
@@ -179,6 +191,14 @@ function applySuggestion(id: string, field: 'max_model_len' | 'max_num_seqs') {
     store.applySuggestedMaxNumSeqs(id)
   }
 }
+
+function toggleOnlyWarnings() {
+  if (onlyWarningsActive.value) {
+    store.setStatusFilter('all')
+  } else {
+    store.setStatusFilter('warn')
+  }
+}
 </script>
 
 <style scoped>
@@ -219,6 +239,12 @@ function applySuggestion(id: string, field: 'max_model_len' | 'max_num_seqs') {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+}
+
+.insights__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
 }
 
 .insights__eyebrow {
@@ -263,6 +289,24 @@ function applySuggestion(id: string, field: 'max_model_len' | 'max_num_seqs') {
   stroke: currentColor;
   stroke-width: 1.8;
   stroke-linecap: round;
+}
+
+.insights__chip {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.4rem 0.9rem;
+}
+
+.insights__chip.is-active {
+  border-color: rgba(56, 189, 248, 0.55);
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.18), rgba(99, 102, 241, 0.28));
+  color: #f8fafc;
 }
 
 .insights__content {

--- a/src/ui/dock/InsightsDrawer.vue
+++ b/src/ui/dock/InsightsDrawer.vue
@@ -35,30 +35,68 @@
         </header>
 
         <section class="insights__content" aria-live="polite" aria-busy="false">
-          <template v-if="rows.length">
-            <article v-for="row in rows" :key="row.id" class="insights__row">
-              <div class="insights__row-head">
-                <div>
-                  <h3 class="insights__row-name">{{ row.name }}</h3>
-                  <p class="insights__row-reason">{{ row.reason }}</p>
+          <div class="insights__section">
+            <h3 class="insights__section-title">Fit Status</h3>
+            <template v-if="rows.length">
+              <article v-for="row in rows" :key="row.id" class="insights__row">
+                <div class="insights__row-head">
+                  <div>
+                    <h4 class="insights__row-name">{{ row.name }}</h4>
+                    <p class="insights__row-reason">{{ row.reason }}</p>
+                  </div>
+                  <span :class="['insights__badge', `is-${row.badge.variant}`]" :title="row.badge.title">
+                    {{ row.badge.label }}
+                  </span>
                 </div>
-                <span :class="['insights__badge', `is-${row.badge.variant}`]" :title="row.badge.title">
-                  {{ row.badge.label }}
-                </span>
-              </div>
-              <dl class="insights__metrics">
-                <div>
-                  <dt>Used</dt>
-                  <dd>{{ row.usedLabel }}</dd>
+                <dl class="insights__metrics">
+                  <div>
+                    <dt>Used</dt>
+                    <dd>{{ row.usedLabel }}</dd>
+                  </div>
+                  <div>
+                    <dt>Free</dt>
+                    <dd>{{ row.freeLabel }}</dd>
+                  </div>
+                </dl>
+              </article>
+            </template>
+            <p v-else class="insights__empty">No GPUs selected yet. Pick a GPU to see fit diagnostics.</p>
+          </div>
+
+          <div class="insights__section">
+            <h3 class="insights__section-title">Suggestions</h3>
+            <template v-if="suggestions.length">
+              <article v-for="suggestion in suggestions" :key="suggestion.id" class="insights__suggestion">
+                <div class="insights__suggestion-head">
+                  <div>
+                    <h4 class="insights__suggestion-name">
+                      {{ suggestion.modelName ?? 'Deployment' }}
+                    </h4>
+                    <p class="insights__suggestion-meta">ID: {{ suggestion.id }}</p>
+                  </div>
                 </div>
-                <div>
-                  <dt>Free</dt>
-                  <dd>{{ row.freeLabel }}</dd>
-                </div>
-              </dl>
-            </article>
-          </template>
-          <p v-else class="insights__empty">No GPUs selected yet. Pick a GPU to see fit diagnostics.</p>
+                <ul class="insights__suggestion-actions">
+                  <li v-for="action in suggestion.actions" :key="action.field" class="insights__suggestion-action">
+                    <div>
+                      <span class="insights__action-label">{{ action.field === 'max_model_len' ? 'max_model_len' : 'max_num_seqs' }}</span>
+                      <span class="insights__action-values">
+                        {{ action.current }} → <strong>{{ action.suggested }}</strong>
+                      </span>
+                    </div>
+                    <button
+                      type="button"
+                      class="insights__apply"
+                      :disabled="!action.canApply"
+                      @click="applySuggestion(suggestion.id, action.field)"
+                    >
+                      Apply
+                    </button>
+                  </li>
+                </ul>
+              </article>
+            </template>
+            <p v-else class="insights__empty">No tuning suggestions at the moment.</p>
+          </div>
         </section>
       </aside>
     </transition>
@@ -70,14 +108,16 @@ import { computed, nextTick, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useAppStore } from '@app/store'
 import { buildInsightRows } from './insightsRows'
+import { buildInsightSuggestions } from './insightsSuggestions'
 import { FOCUSABLE_SELECTOR, getNextFocusable, isFocusableCandidate } from './focusLoop'
+import type { AppState } from '@app/state'
 
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
 
 const rootRef = ref<HTMLElement | null>(null)
 const store = useAppStore()
-const { fitStatus, gpus, gpuCatalog, unit } = storeToRefs(store)
+const { fitStatus, gpus, gpuCatalog, unit, deployments } = storeToRefs(store)
 
 const rows = computed(() =>
   buildInsightRows({
@@ -85,6 +125,12 @@ const rows = computed(() =>
     gpus: gpus.value,
     gpuCatalog: gpuCatalog.value,
     unit: unit.value,
+  })
+)
+
+const suggestions = computed(() =>
+  buildInsightSuggestions({
+    state: { ...store.$state, deployments: deployments.value } as AppState,
   })
 )
 
@@ -124,6 +170,14 @@ function onKeydown(event: KeyboardEvent) {
 
 function onClose() {
   emit('close')
+}
+
+function applySuggestion(id: string, field: 'max_model_len' | 'max_num_seqs') {
+  if (field === 'max_model_len') {
+    store.applySuggestedMaxModelLen(id)
+  } else {
+    store.applySuggestedMaxNumSeqs(id)
+  }
 }
 </script>
 
@@ -217,7 +271,16 @@ function onClose() {
   padding: 0 1.5rem 1.75rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
+}
+
+.insights__section-title {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.82);
 }
 
 .insights__row {
@@ -303,6 +366,71 @@ function onClose() {
   margin: 2rem 0;
   text-align: center;
   color: rgba(148, 163, 184, 0.85);
+}
+
+.insights__suggestion {
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.insights__suggestion-name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.94);
+}
+
+.insights__suggestion-meta {
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.insights__suggestion-actions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.insights__suggestion-action {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.insights__action-label {
+  font-size: 0.82rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.82);
+  display: block;
+}
+
+.insights__action-values {
+  font-size: 0.95rem;
+  color: rgba(248, 250, 252, 0.94);
+}
+
+.insights__apply {
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.5);
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.22), rgba(99, 102, 241, 0.32));
+  color: #f8fafc;
+  font-weight: 600;
+  padding: 0.45rem 1.1rem;
+}
+
+.insights__apply:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .insights-fade-enter-active,

--- a/src/ui/dock/InsightsDrawer.vue
+++ b/src/ui/dock/InsightsDrawer.vue
@@ -1,13 +1,345 @@
 <template>
-  <aside
-    class="fixed inset-y-0 right-0 w-[360px] max-w-[80vw] bg-white dark:bg-slate-900 border-l shadow-xl p-4 hidden"
-    aria-label="Insights Drawer"
-  >
-    <div class="text-xs text-slate-500">Insights Drawer (stub)</div>
-  </aside>
+  <Teleport to="body">
+    <transition name="insights-fade">
+      <button
+        v-if="open"
+        type="button"
+        class="insights__scrim"
+        aria-hidden="true"
+        tabindex="-1"
+        @click="onClose"
+      />
+    </transition>
+    <transition name="insights-slide">
+      <aside
+        v-if="open"
+        ref="rootRef"
+        class="insights"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="insights-title"
+        data-test="insights-drawer"
+        @keydown.capture="onKeydown"
+      >
+        <header class="insights__header">
+          <div class="insights__titles">
+            <span class="insights__eyebrow">System Insights</span>
+            <h2 id="insights-title">Fit Status Overview</h2>
+            <p class="insights__subtitle">Monitor capacity pressure across selected GPUs.</p>
+          </div>
+          <button type="button" class="insights__close" aria-label="Close Insights" @click="onClose">
+            <svg aria-hidden="true" viewBox="0 0 16 16" class="insights__close-icon">
+              <path d="M3.2 3.2L12.8 12.8M12.8 3.2L3.2 12.8" />
+            </svg>
+          </button>
+        </header>
+
+        <section class="insights__content" aria-live="polite" aria-busy="false">
+          <template v-if="rows.length">
+            <article v-for="row in rows" :key="row.id" class="insights__row">
+              <div class="insights__row-head">
+                <div>
+                  <h3 class="insights__row-name">{{ row.name }}</h3>
+                  <p class="insights__row-reason">{{ row.reason }}</p>
+                </div>
+                <span :class="['insights__badge', `is-${row.badge.variant}`]" :title="row.badge.title">
+                  {{ row.badge.label }}
+                </span>
+              </div>
+              <dl class="insights__metrics">
+                <div>
+                  <dt>Used</dt>
+                  <dd>{{ row.usedLabel }}</dd>
+                </div>
+                <div>
+                  <dt>Free</dt>
+                  <dd>{{ row.freeLabel }}</dd>
+                </div>
+              </dl>
+            </article>
+          </template>
+          <p v-else class="insights__empty">No GPUs selected yet. Pick a GPU to see fit diagnostics.</p>
+        </section>
+      </aside>
+    </transition>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
-// Stub
+import { computed, nextTick, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useAppStore } from '@app/store'
+import { buildInsightRows } from './insightsRows'
+import { FOCUSABLE_SELECTOR, getNextFocusable, isFocusableCandidate } from './focusLoop'
+
+const props = defineProps<{ open: boolean }>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const rootRef = ref<HTMLElement | null>(null)
+const store = useAppStore()
+const { fitStatus, gpus, gpuCatalog, unit } = storeToRefs(store)
+
+const rows = computed(() =>
+  buildInsightRows({
+    fit: fitStatus.value ?? [],
+    gpus: gpus.value,
+    gpuCatalog: gpuCatalog.value,
+    unit: unit.value,
+  })
+)
+
+watch(
+  () => props.open,
+  (open) => {
+    if (!open) return
+    nextTick(() => {
+      const focusable = getFocusableElements()
+      if (focusable.length) focusable[0].focus()
+    })
+  }
+)
+
+function getFocusableElements(): HTMLElement[] {
+  const root = rootRef.value
+  if (!root) return []
+  const nodes = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+  return nodes.filter(isFocusableCandidate)
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    emit('close')
+    return
+  }
+  if (event.key !== 'Tab') return
+  const focusables = getFocusableElements()
+  if (!focusables.length) return
+  const current = document.activeElement as HTMLElement | null
+  const next = getNextFocusable(focusables, current, event.shiftKey)
+  if (!next) return
+  event.preventDefault()
+  next.focus()
+}
+
+function onClose() {
+  emit('close')
+}
 </script>
 
+<style scoped>
+.insights__scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(9, 12, 18, 0.46);
+  backdrop-filter: blur(12px);
+  z-index: 40;
+  border: none;
+  cursor: pointer;
+}
+
+.insights {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: min(520px, 62vw);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.96) 0%, rgba(9, 13, 21, 0.96) 100%);
+  border-left: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 20px 60px rgba(7, 10, 18, 0.55);
+  z-index: 41;
+  display: flex;
+  flex-direction: column;
+  color: rgba(248, 250, 252, 0.95);
+}
+
+.insights__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem 1rem;
+}
+
+.insights__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.insights__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.insights__titles h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.01em;
+}
+
+.insights__subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.insights__close {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(248, 250, 252, 0.92);
+  width: 2.35rem;
+  aspect-ratio: 1 / 1;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.insights__close:hover {
+  border-color: rgba(148, 163, 184, 0.6);
+  background: rgba(31, 41, 55, 0.6);
+}
+
+.insights__close-icon {
+  width: 1.15rem;
+  height: 1.15rem;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+}
+
+.insights__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 1.5rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.insights__row {
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.insights__row-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+}
+
+.insights__row-name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.94);
+}
+
+.insights__row-reason {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.insights__badge {
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+}
+
+.insights__badge.is-ok {
+  border-color: rgba(48, 209, 88, 0.5);
+  color: #30d158;
+  background: rgba(48, 209, 88, 0.12);
+}
+
+.insights__badge.is-warn {
+  border-color: rgba(255, 159, 10, 0.55);
+  color: #ffb020;
+  background: rgba(255, 159, 10, 0.16);
+}
+
+.insights__badge.is-over {
+  border-color: rgba(255, 83, 73, 0.65);
+  color: #ff4d4f;
+  background: rgba(255, 83, 73, 0.18);
+}
+
+.insights__metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.insights__metrics dt {
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.78);
+  margin: 0;
+}
+
+.insights__metrics dd {
+  margin: 0.2rem 0 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.94);
+}
+
+.insights__empty {
+  margin: 2rem 0;
+  text-align: center;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.insights-fade-enter-active,
+.insights-fade-leave-active {
+  transition: opacity 160ms ease;
+}
+
+.insights-fade-enter-from,
+.insights-fade-leave-to {
+  opacity: 0;
+}
+
+.insights-slide-enter-active,
+.insights-slide-leave-active {
+  transition: transform 200ms ease, opacity 200ms ease;
+}
+
+.insights-slide-enter-from,
+.insights-slide-leave-to {
+  transform: translateX(16px);
+  opacity: 0;
+}
+
+@media (max-width: 960px) {
+  .insights {
+    width: min(100vw, 540px);
+  }
+}
+
+@media (max-width: 768px) {
+  .insights {
+    left: 0;
+    width: 100vw;
+    border-left: none;
+    border-top: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 24px 24px 0 0;
+    box-shadow: 0 20px 60px rgba(7, 10, 18, 0.45);
+  }
+}
+</style>

--- a/src/ui/dock/insightsRows.test.ts
+++ b/src/ui/dock/insightsRows.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { buildInsightRows } from './insightsRows'
+import type { FitStatusEntry } from '../status/fitBadge'
+import type { Gpu, UnitPreference } from '@shared/types'
+
+const sampleGpus: Gpu[] = [
+  { id: 'gpu-a', name: 'A100', vendor: 'NVIDIA', vramBytes: 80 * 1024 ** 3 },
+  { id: 'gpu-b', name: 'H100', vendor: 'NVIDIA', vramBytes: 120 * 1024 ** 3 },
+]
+
+const fitEntries: FitStatusEntry[] = [
+  { gpuId: 'gpu-b', ok: false, reason: 'Over capacity', used: 1000, free: 0 },
+  { gpuId: 'gpu-c', ok: true, reason: 'High utilization >95%', used: 500, free: 200 },
+  { gpuId: 'gpu-a', ok: true, used: 100, free: 900 },
+]
+
+const unit: UnitPreference = 'GiB'
+
+describe('buildInsightRows', () => {
+  it('sorts rows by severity and formats labels', () => {
+    const rows = buildInsightRows({ fit: fitEntries, gpus: sampleGpus, gpuCatalog: sampleGpus, unit })
+    expect(rows.map((r) => r.id)).toEqual(['gpu-b', 'gpu-c', 'gpu-a'])
+    expect(rows[0].badge.label).toBe('Over')
+    expect(rows[1].badge.label).toBe('Warning')
+    expect(rows[2].badge.label).toBe('OK')
+    expect(rows[0].usedLabel).toMatch(/GiB$/)
+    expect(rows[2].reason).toBe('Within capacity')
+  })
+
+  it('falls back to GPU id when name missing', () => {
+    const rows = buildInsightRows({ fit: fitEntries, gpus: [], gpuCatalog: [], unit })
+    const ids = rows.map((r) => r.name)
+    expect(ids).toContain('gpu-b')
+  })
+})

--- a/src/ui/dock/insightsRows.ts
+++ b/src/ui/dock/insightsRows.ts
@@ -1,0 +1,61 @@
+import type { FitStatusEntry, FitBadge } from '../status/fitBadge'
+import { resolveFitBadge } from '../status/fitBadge'
+import type { UnitPreference, Gpu } from '@shared/types'
+import { formatBytes } from '@shared/units'
+
+export interface InsightRow {
+  id: string
+  name: string
+  badge: FitBadge
+  reason: string
+  usedLabel: string
+  freeLabel: string
+}
+
+interface BuildRowsInput {
+  fit: readonly FitStatusEntry[]
+  gpus: readonly Gpu[]
+  gpuCatalog: readonly Gpu[]
+  unit: UnitPreference
+}
+
+const SEVERITY_RANK: Record<FitBadge['variant'], number> = {
+  over: 0,
+  warn: 1,
+  ok: 2,
+}
+
+export function buildInsightRows(input: BuildRowsInput): InsightRow[] {
+  const gpuNameById = new Map<string, string>()
+  for (const gpu of input.gpus) {
+    gpuNameById.set(gpu.id, gpu.name)
+  }
+  for (const gpu of input.gpuCatalog) {
+    if (!gpuNameById.has(gpu.id)) {
+      gpuNameById.set(gpu.id, gpu.name)
+    }
+  }
+
+  const rows = input.fit.map((entry) => {
+    const badge = resolveFitBadge(entry)
+    const name = gpuNameById.get(entry.gpuId) || entry.gpuId
+    const usedLabel = formatBytes(entry.used, input.unit, 1)
+    const freeLabel = formatBytes(entry.free, input.unit, 1)
+    const reason = entry.reason || (badge.variant === 'ok' ? 'Within capacity' : badge.title)
+
+    return {
+      id: entry.gpuId,
+      name,
+      badge,
+      reason,
+      usedLabel,
+      freeLabel,
+    }
+  })
+
+  return rows.sort((a, b) => {
+    const severityDelta = SEVERITY_RANK[a.badge.variant] - SEVERITY_RANK[b.badge.variant]
+    if (severityDelta !== 0) return severityDelta
+    return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  })
+}

--- a/src/ui/dock/insightsSuggestions.test.ts
+++ b/src/ui/dock/insightsSuggestions.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { buildInsightSuggestions } from './insightsSuggestions'
+import type { AppState } from '@app/state'
+import { createInitialState } from '@app/state'
+import type { Deployment, Model } from '@shared/types'
+
+vi.mock('@app/controller', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@app/controller')>()
+  return {
+    ...actual,
+    computeDeploymentSuggestions: vi.fn(),
+  }
+})
+
+import { computeDeploymentSuggestions } from '@app/controller'
+
+function makeState(): AppState {
+  const base = createInitialState()
+  const models: Model[] = [
+    {
+      id: 'm1',
+      name: 'Model One',
+      paramsB: 10,
+      layers: 20,
+      hiddenSize: 4096,
+      heads: 32,
+      numKeyValueHeads: 8,
+      defaultWeightDtype: 'bf16',
+      defaultKvDtype: 'fp16',
+    },
+  ]
+  const deployments: Deployment[] = [
+    {
+      id: 'dep-1',
+      modelId: 'm1',
+      assignedGpuIds: [],
+      tp: 1,
+      weightDtype: 'bf16',
+      kvDtype: 'fp16',
+      kvOverheadPct: 0.1,
+      replicationOverheadPct: 0.02,
+      maxModelLen: 4096,
+      maxNumSeqs: 1,
+    },
+    {
+      id: 'dep-2',
+      modelId: 'm1',
+      assignedGpuIds: [],
+      tp: 1,
+      weightDtype: 'bf16',
+      kvDtype: 'fp16',
+      kvOverheadPct: 0.1,
+      replicationOverheadPct: 0.02,
+      maxModelLen: 2048,
+      maxNumSeqs: 2,
+    },
+  ]
+  return { ...base, models, deployments }
+}
+
+describe('buildInsightSuggestions', () => {
+  beforeEach(() => {
+    vi.mocked(computeDeploymentSuggestions).mockImplementation((state, id) => {
+      if (id === 'dep-1') {
+        return { maxModelLen: 8192, maxNumSeqs: 4 }
+      }
+      if (id === 'dep-2') {
+        return { maxModelLen: 2048, maxNumSeqs: 2 }
+      }
+      return { maxModelLen: 0, maxNumSeqs: 0 }
+    })
+  })
+
+  it('returns actionable suggestions sorted by impact', () => {
+    const state = makeState()
+    const rows = buildInsightSuggestions({ state })
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('dep-1')
+    expect(rows[0].actions).toHaveLength(2)
+    const [len, seqs] = rows[0].actions
+    expect(len.field).toBe('max_model_len')
+    expect(len.canApply).toBe(true)
+    expect(len.suggested).toBe(8192)
+    expect(seqs.field).toBe('max_num_seqs')
+    expect(seqs.delta).toBe(3)
+  })
+
+  it('skips deployments without actionable deltas', () => {
+    const state = makeState()
+    vi.mocked(computeDeploymentSuggestions).mockImplementation((s, id) => {
+      const deployment = s.deployments.find((d) => d.id === id)
+      return {
+        maxModelLen: deployment?.maxModelLen ?? 0,
+        maxNumSeqs: deployment?.maxNumSeqs ?? 0,
+      }
+    })
+    const rows = buildInsightSuggestions({ state })
+    expect(rows).toHaveLength(0)
+  })
+})

--- a/src/ui/dock/insightsSuggestions.ts
+++ b/src/ui/dock/insightsSuggestions.ts
@@ -1,0 +1,59 @@
+import type { AppState } from '@app/state'
+import { computeDeploymentSuggestions } from '@app/controller'
+
+export interface SuggestionAction {
+  field: 'max_model_len' | 'max_num_seqs'
+  current: number
+  suggested: number
+  delta: number
+  canApply: boolean
+}
+
+export interface InsightSuggestion {
+  id: string
+  name: string
+  modelName?: string
+  actions: SuggestionAction[]
+  impactScore: number
+}
+
+interface BuildSuggestionsInput {
+  state: AppState
+}
+
+function createAction(field: SuggestionAction['field'], current: number, suggested: number): SuggestionAction {
+  const delta = suggested - current
+  const canApply = suggested > 0 && Math.abs(delta) > 0
+  return { field, current, suggested, delta, canApply }
+}
+
+export function buildInsightSuggestions({ state }: BuildSuggestionsInput): InsightSuggestion[] {
+  const modelsById = new Map(state.models.map((m) => [m.id, m]))
+  const suggestions: InsightSuggestion[] = []
+
+  for (const deployment of state.deployments) {
+    const next = computeDeploymentSuggestions(state, deployment.id)
+    const len = createAction('max_model_len', deployment.maxModelLen, next.maxModelLen)
+    const seqs = createAction('max_num_seqs', deployment.maxNumSeqs, next.maxNumSeqs)
+    const actionable = [len, seqs].filter((action) => action.canApply)
+    if (!actionable.length) continue
+
+    const model = modelsById.get(deployment.modelId)
+    const impactScore = actionable.reduce((sum, action) => sum + Math.abs(action.delta), 0)
+
+    suggestions.push({
+      id: deployment.id,
+      name: deployment.id,
+      modelName: model?.name,
+      actions: actionable,
+      impactScore,
+    })
+  }
+
+  return suggestions.sort((a, b) => {
+    if (b.impactScore !== a.impactScore) return b.impactScore - a.impactScore
+    const nameA = a.modelName ?? a.name
+    const nameB = b.modelName ?? b.name
+    return nameA.localeCompare(nameB, undefined, { sensitivity: 'base' })
+  })
+}

--- a/src/ui/dock/shortcutResolver.test.ts
+++ b/src/ui/dock/shortcutResolver.test.ts
@@ -45,7 +45,7 @@ describe('resolveDockShortcut', () => {
   })
 
   it('returns insights toggle for F key', () => {
-    expect(resolveDockShortcut(makeEvent({ key: 'F' }))).toEqual({ type: 'insights' })
+    expect(resolveDockShortcut(makeEvent({ key: 'f' }))).toEqual({ type: 'insights' })
   })
 
   it('ignores events with modifier keys', () => {

--- a/src/ui/dock/shortcutResolver.test.ts
+++ b/src/ui/dock/shortcutResolver.test.ts
@@ -44,6 +44,10 @@ describe('resolveDockShortcut', () => {
     expect(resolveDockShortcut(makeEvent({ key: 'w' }))).toEqual({ type: 'tab', tab: 'workload' })
   })
 
+  it('returns insights toggle for F key', () => {
+    expect(resolveDockShortcut(makeEvent({ key: 'F' }))).toEqual({ type: 'insights' })
+  })
+
   it('ignores events with modifier keys', () => {
     const event = makeEvent({ key: 'e', ctrlKey: true })
     expect(resolveDockShortcut(event)).toBeNull()

--- a/src/ui/dock/shortcutResolver.ts
+++ b/src/ui/dock/shortcutResolver.ts
@@ -5,6 +5,7 @@ const BLOCKED_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT'])
 export type DockShortcut =
   | { type: 'toggle' }
   | { type: 'tab'; tab: ControlDockTab }
+  | { type: 'insights' }
 
 function isInputLike(target: HTMLElement | null): boolean {
   if (!target) return false
@@ -30,5 +31,6 @@ export function resolveDockShortcut(event: KeyboardEvent): DockShortcut | null {
   if (key === 'g') return { type: 'tab', tab: 'gpus' }
   if (key === 'm') return { type: 'tab', tab: 'models' }
   if (key === 'w') return { type: 'tab', tab: 'workload' }
+  if (key === 'f') return { type: 'insights' }
   return null
 }

--- a/src/ui/shell/DashboardShell.vue
+++ b/src/ui/shell/DashboardShell.vue
@@ -14,7 +14,7 @@
         @close="closeDock"
         @change-tab="setActiveTab"
       />
-      <InsightsDrawer class="hidden" />
+      <InsightsDrawer :open="isInsightsOpen" @close="closeInsights" />
       <TileInspector class="hidden" />
     </main>
     <FooterBar />
@@ -36,6 +36,7 @@ import { resolveDockShortcut } from '../dock/shortcutResolver'
 const { isOpen, activeTab, open, close, setTab } = useControlDockState('gpus')
 const isDockOpen = isOpen
 const commandToggleRef = ref<HTMLElement | null>(null)
+const isInsightsOpen = ref(false)
 
 interface DockTabSelection {
   tab: ControlDockTab
@@ -74,6 +75,10 @@ function closeDock() {
 
 function setActiveTab(tab: ControlDockTab) {
   setTab(tab)
+}
+
+function closeInsights() {
+  isInsightsOpen.value = false
 }
 
 function onCommandStripToggle(trigger?: HTMLElement | null) {

--- a/src/ui/shell/DashboardShell.vue
+++ b/src/ui/shell/DashboardShell.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import CommandStrip from './CommandStrip.vue'
 import VizCanvas from '../viz/VizCanvas.vue'
 import ControlDock from '../dock/ControlDock.vue'
@@ -32,11 +32,14 @@ import FooterBar from '../FooterBar.vue'
 import type { ControlDockTab } from '../dock/dockTypes'
 import { useControlDockState } from '../dock/useControlDockState'
 import { resolveDockShortcut } from '../dock/shortcutResolver'
+import { useAppStore } from '@app/store'
 
 const { isOpen, activeTab, open, close, setTab } = useControlDockState('gpus')
 const isDockOpen = isOpen
 const commandToggleRef = ref<HTMLElement | null>(null)
 const isInsightsOpen = ref(false)
+const insightsLastTrigger = ref<HTMLElement | null>(null)
+const store = useAppStore()
 
 interface DockTabSelection {
   tab: ControlDockTab
@@ -77,8 +80,22 @@ function setActiveTab(tab: ControlDockTab) {
   setTab(tab)
 }
 
+function openInsights(trigger?: HTMLElement | null, setWarnings = false) {
+  if (setWarnings) {
+    store.setStatusFilter('warn')
+  }
+  const resolved = resolveTrigger(trigger)
+  if (resolved) insightsLastTrigger.value = resolved
+  isInsightsOpen.value = true
+}
+
 function closeInsights() {
+  if (!isInsightsOpen.value) return
   isInsightsOpen.value = false
+  const trigger = insightsLastTrigger.value
+  if (trigger) {
+    nextTick(() => trigger.focus?.())
+  }
 }
 
 function onCommandStripToggle(trigger?: HTMLElement | null) {
@@ -100,7 +117,19 @@ function onGlobalKeydown(event: KeyboardEvent) {
     toggleDock(invoker)
     return
   }
-  activateDockTab(action.tab, invoker)
+  if (action.type === 'tab') {
+    activateDockTab(action.tab, invoker)
+    return
+  }
+  if (action.type === 'insights') {
+    const warningsActive = store.viewPrefs.statusFilter === 'warn'
+    if (isInsightsOpen.value && warningsActive) {
+      store.setStatusFilter('all')
+      closeInsights()
+    } else {
+      openInsights(invoker, true)
+    }
+  }
 }
 
 onMounted(() => {

--- a/src/ui/status/fitBadge.ts
+++ b/src/ui/status/fitBadge.ts
@@ -1,0 +1,38 @@
+export interface FitStatusEntry {
+  gpuId: string
+  ok: boolean
+  reason?: string
+  used: number
+  free: number
+}
+
+export interface FitBadge {
+  variant: 'ok' | 'warn' | 'over'
+  label: 'OK' | 'Warning' | 'Over'
+  title: string
+}
+
+export function resolveFitBadge(entry: FitStatusEntry): FitBadge {
+  if (!entry.ok) {
+    return {
+      variant: 'over',
+      label: 'Over',
+      title: entry.reason || 'Over capacity or no headroom',
+    }
+  }
+
+  const reason = entry.reason || 'Within capacity'
+  if (reason.toLowerCase().includes('high utilization')) {
+    return {
+      variant: 'warn',
+      label: 'Warning',
+      title: reason,
+    }
+  }
+
+  return {
+    variant: 'ok',
+    label: 'OK',
+    title: reason,
+  }
+}

--- a/src/ui/viz/PerGpuWaffle.vue
+++ b/src/ui/viz/PerGpuWaffle.vue
@@ -41,30 +41,10 @@ import { storeToRefs } from 'pinia'
 import { useAppStore } from '@app/store'
 import { gpuCapacityLabel, type WaffleCategory } from '@app/controller'
 import type { Gpu } from '@shared/types'
+import { resolveFitBadge } from '../status/fitBadge'
 
 const store = useAppStore()
 const { waffleCells, fitStatus } = storeToRefs(store)
-
-type TileStatus = {
-  text: 'Over' | 'Warning' | 'OK'
-  class: string
-  title: string
-}
-
-function resolveStatus(gpuId: string): TileStatus {
-  const status = fitStatus.value.find((s) => s.gpuId === gpuId)
-  if (!status) {
-    return { text: 'OK', class: 'is-ok', title: 'No status available' }
-  }
-  const reason = status.reason ?? ''
-  if (!status.ok) {
-    return { text: 'Over', class: 'is-over', title: reason || 'Over capacity or no headroom' }
-  }
-  if (reason.includes('High utilization')) {
-    return { text: 'Warning', class: 'is-warn', title: reason }
-  }
-  return { text: 'OK', class: 'is-ok', title: reason || 'Within capacity' }
-}
 
 const order: WaffleCategory[] = ['weights', 'kv', 'reserve', 'free']
 
@@ -87,7 +67,8 @@ function percentOf(value: number, capacity: number): string {
 
 const tiles = computed(() => {
   return (waffleCells.value ?? []).map((entry) => {
-    const status = resolveStatus(entry.gpuId)
+    const rawStatus = fitStatus.value.find((s) => s.gpuId === entry.gpuId)
+    const badge = rawStatus ? resolveFitBadge(rawStatus) : { variant: 'ok', label: 'OK', title: 'No status available' }
     const totalCells = entry.totalCells || entry.gridSize ** 2
     const cells = expandCells(entry.cells, totalCells)
     const usedBytes = entry.weightsBytes + entry.kvBytes
@@ -104,9 +85,9 @@ const tiles = computed(() => {
       gpuId: entry.gpuId,
       gpuName: entry.gpuName,
       capacityLabel: gpuCapacityLabel(gpuMeta),
-      statusText: status.text,
-      statusClass: status.class,
-      statusTitle: status.title,
+      statusText: badge.label,
+      statusClass: badge.variant === 'over' ? 'is-over' : badge.variant === 'warn' ? 'is-warn' : 'is-ok',
+      statusTitle: badge.title,
       gridSize: entry.gridSize,
       cells,
       usedPercent,


### PR DESCRIPTION
This pull request implements and tests a new Insights Drawer overlay for the dashboard, providing actionable GPU fit status and deployment suggestions, and adds a keyboard shortcut (`F`) to quickly open or toggle the drawer with a "show only warnings" filter. The implementation includes reusable utilities for formatting fit status rows and suggestions, improves state management and accessibility, and adds comprehensive tests for the new features.

**Insights Drawer Overlay and Utilities:**

- Implemented the `InsightsDrawer` overlay, including a fit status list using a new `buildInsightRows` utility, a reusable badge helper (`resolveFitBadge`), and a utility for formatting insight rows, all with corresponding tests. Also updated the concise repo assessment documentation to reflect these changes. [[1]](diffhunk://#diff-8641f2681e2116a75bf8c6c4a1e596fc55cf4490d2dfcbcf552e203dd569dbe5L92-R106) [[2]](diffhunk://#diff-cc46e26c94d7b7e4e9d3566fcbe3a022ac85a7f6420e518930761c73971cc479R1-R61) [[3]](diffhunk://#diff-fef219b407093d79643cd07f20d43d182aceb8d6393e26f45cddadd76e89a56fR1-R38) [[4]](diffhunk://#diff-4a2ba457dbe388d1b0ffef3c5f30a4632ac2b8367c712f4b61c3309913bbe2efR1-R35)

- Added a suggestions helper (`buildInsightSuggestions`) with tests, surfacing actionable suggestions with "Apply" actions in the Insights Drawer, and wiring them to store actions for immediate deployment updates. [[1]](diffhunk://#diff-8641f2681e2116a75bf8c6c4a1e596fc55cf4490d2dfcbcf552e203dd569dbe5L92-R106) [[2]](diffhunk://#diff-d33f645e41558abe668146c01b10e48f94e2c1fe8525322808b94c69ad068694R1-R59) [[3]](diffhunk://#diff-f2e78349f386f781213885e09980ff255ac932fde7c8e4430ea02106bd2e3f8cR1-R100)

**Keyboard Shortcut and Drawer Integration:**

- Introduced a new keyboard shortcut (`F`) to toggle the Insights Drawer and set the status filter to "warnings only," updating the shortcut resolver and adding related tests. [[1]](diffhunk://#diff-8641f2681e2116a75bf8c6c4a1e596fc55cf4490d2dfcbcf552e203dd569dbe5L92-R106) [[2]](diffhunk://#diff-0f9f52beba4dd65ed8daad48ca6ab5d62780aa86361613993f9e62312783244fR47-R50) [[3]](diffhunk://#diff-2ff47924799571f67fc91c4d75f9da155f3514725d7af602cf67aa959caf9e35R8) [[4]](diffhunk://#diff-2ff47924799571f67fc91c4d75f9da155f3514725d7af602cf67aa959caf9e35R34)

- Refactored `DashboardShell.vue` to manage the Insights Drawer open/close state, focus handling, and integration with the status filter and shortcut logic. [[1]](diffhunk://#diff-5bede366de13bb91e2bd7d458b55f70cae3075eba0f544bc1615d00fd2d6701aL17-R25) [[2]](diffhunk://#diff-5bede366de13bb91e2bd7d458b55f70cae3075eba0f544bc1615d00fd2d6701aR35-R42) [[3]](diffhunk://#diff-5bede366de13bb91e2bd7d458b55f70cae3075eba0f544bc1615d00fd2d6701aR83-R100) [[4]](diffhunk://#diff-5bede366de13bb91e2bd7d458b55f70cae3075eba0f544bc1615d00fd2d6701aR120-R132)

**Fit Status Badge Refactor:**

- Centralized fit status badge logic into `resolveFitBadge`, and updated `PerGpuWaffle.vue` to use this utility for consistent badge rendering and status labeling. [[1]](diffhunk://#diff-fef219b407093d79643cd07f20d43d182aceb8d6393e26f45cddadd76e89a56fR1-R38) [[2]](diffhunk://#diff-a31ba9ce13ba3a81a3fae4810b961cad4272d1b491ed6c31dbefb4bb0f456978R44-L68) [[3]](diffhunk://#diff-a31ba9ce13ba3a81a3fae4810b961cad4272d1b491ed6c31dbefb4bb0f456978L90-R71) [[4]](diffhunk://#diff-a31ba9ce13ba3a81a3fae4810b961cad4272d1b491ed6c31dbefb4bb0f456978L107-R90)